### PR TITLE
refactor: test infrastructure — real tmux/git over fakes

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,8 +1,14 @@
 package cmd
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 )
+
+// NOTE: Cobra commands are not thread-safe. Tests that call SetArgs/SetOut/Execute
+// on the package-level rootCmd must NOT use t.Parallel(). Tests that only read
+// rootCmd fields can be parallel.
 
 func TestRootCommandExists(t *testing.T) {
 	t.Parallel()
@@ -17,7 +23,7 @@ func TestRootCommandExists(t *testing.T) {
 }
 
 func TestVersionCommandRegistered(t *testing.T) {
-	t.Parallel()
+	// Not parallel — reads rootCmd.Commands() which sorts internally.
 
 	var found bool
 	for _, cmd := range rootCmd.Commands() {
@@ -30,4 +36,46 @@ func TestVersionCommandRegistered(t *testing.T) {
 	if !found {
 		t.Fatal("expected 'version' subcommand to be registered")
 	}
+}
+
+func TestVersionCommandOutput(t *testing.T) {
+	// Not parallel — mutates rootCmd via SetOut/SetArgs.
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"version"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("version command failed: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.HasPrefix(out, "rocket-fuel") {
+		t.Errorf("expected output to start with 'rocket-fuel', got %q", out)
+	}
+
+	// Reset for other tests.
+	rootCmd.SetOut(nil)
+	rootCmd.SetArgs(nil)
+}
+
+func TestHelpContainsDescription(t *testing.T) {
+	// Not parallel — mutates rootCmd via SetOut/SetArgs.
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"--help"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("help failed: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Visionary/Integrator") {
+		t.Errorf("expected help to mention 'Visionary/Integrator', got %q", out)
+	}
+
+	// Reset for other tests.
+	rootCmd.SetOut(nil)
+	rootCmd.SetArgs(nil)
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -12,8 +12,8 @@ var Version = "dev"
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version of Rocket Fuel",
-	Run: func(_ *cobra.Command, _ []string) {
-		fmt.Printf("rocket-fuel %s\n", Version)
+	Run: func(cmd *cobra.Command, _ []string) {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "rocket-fuel %s\n", Version)
 	},
 }
 

--- a/internal/testutil/git.go
+++ b/internal/testutil/git.go
@@ -1,0 +1,76 @@
+package testutil
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// InitTestRepo creates a real git repo in a temp directory with an initial commit.
+// Returns the repo path. Cleanup is automatic via t.TempDir().
+func InitTestRepo(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	commands := [][]string{
+		{"git", "init"},
+		{"git", "config", "user.email", "test@rocket-fuel.dev"},
+		{"git", "config", "user.name", "Rocket Fuel Test"},
+		{"git", "commit", "--allow-empty", "-m", "initial commit"},
+	}
+
+	for _, args := range commands {
+		cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+		cmd.Dir = dir
+
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%s failed: %v\n%s", args[0], err, out)
+		}
+	}
+
+	return dir
+}
+
+// InitTestRepoWithWorktree creates a repo and adds a worktree.
+// Returns (repo path, worktree path). Both cleaned up automatically.
+func InitTestRepoWithWorktree(t *testing.T, worktreeName string) (string, string) {
+	t.Helper()
+
+	repoDir := InitTestRepo(t)
+	ctx := context.Background()
+	worktreeDir := filepath.Join(t.TempDir(), worktreeName)
+	branchName := "rf/" + worktreeName
+
+	cmd := exec.CommandContext(ctx, "git", "worktree", "add", "-b", branchName, worktreeDir)
+	cmd.Dir = repoDir
+
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add failed: %v\n%s", err, out)
+	}
+
+	t.Cleanup(func() {
+		remove := exec.CommandContext(context.Background(), "git", "worktree", "remove", "--force", worktreeDir)
+		remove.Dir = repoDir
+		_ = remove.Run() //nolint:errcheck // best-effort cleanup
+	})
+
+	return repoDir, worktreeDir
+}
+
+// GitRun executes a git command in the given directory and returns stdout.
+func GitRun(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.CommandContext(context.Background(), "git", args...)
+	cmd.Dir = dir
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed in %s: %v\n%s", args, dir, err, out)
+	}
+
+	return string(out)
+}

--- a/internal/testutil/git_test.go
+++ b/internal/testutil/git_test.go
@@ -1,0 +1,60 @@
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInitTestRepoCreatesGitRepo(t *testing.T) {
+	t.Parallel()
+
+	repoDir := InitTestRepo(t)
+
+	// .git directory should exist
+	gitDir := filepath.Join(repoDir, ".git")
+	if _, err := os.Stat(gitDir); os.IsNotExist(err) {
+		t.Fatalf("expected .git directory at %s", gitDir)
+	}
+
+	// Should have at least one commit
+	log := GitRun(t, repoDir, "log", "--oneline")
+	if !strings.Contains(log, "initial commit") {
+		t.Errorf("expected initial commit in log, got: %s", log)
+	}
+}
+
+func TestInitTestRepoWithWorktree(t *testing.T) {
+	t.Parallel()
+
+	repoDir, worktreeDir := InitTestRepoWithWorktree(t, "worker-1")
+
+	// Worktree directory should exist
+	if _, err := os.Stat(worktreeDir); os.IsNotExist(err) {
+		t.Fatalf("expected worktree directory at %s", worktreeDir)
+	}
+
+	// Worktree should be on the correct branch
+	branch := strings.TrimSpace(GitRun(t, worktreeDir, "branch", "--show-current"))
+	if branch != "rf/worker-1" {
+		t.Errorf("expected branch 'rf/worker-1', got %q", branch)
+	}
+
+	// Main repo should list the worktree
+	worktrees := GitRun(t, repoDir, "worktree", "list")
+	if !strings.Contains(worktrees, worktreeDir) {
+		t.Errorf("expected worktree list to contain %s, got: %s", worktreeDir, worktrees)
+	}
+}
+
+func TestGitRunExecutesCommands(t *testing.T) {
+	t.Parallel()
+
+	repoDir := InitTestRepo(t)
+
+	status := GitRun(t, repoDir, "status", "--porcelain")
+	if strings.TrimSpace(status) != "" {
+		t.Errorf("expected clean status, got: %q", status)
+	}
+}

--- a/internal/testutil/tmux.go
+++ b/internal/testutil/tmux.go
@@ -1,9 +1,134 @@
 package testutil
 
-import "testing"
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
 
-// FakeTmux records tmux commands for testing without a real tmux server.
-type FakeTmux struct {
+// testSocket is the isolated tmux socket name for this test process.
+// Set by SetupTmuxSocket in TestMain, used by NewRealTmux.
+var testSocket string
+
+// SetupTmuxSocket creates an isolated tmux socket for the test process.
+// Call this in TestMain for packages that need real tmux integration tests.
+// Returns a cleanup function that kills the tmux server on that socket.
+//
+// Pattern (from gastown):
+//
+//	func TestMain(m *testing.M) {
+//	    cleanup := testutil.SetupTmuxSocket()
+//	    code := m.Run()
+//	    cleanup()
+//	    os.Exit(code)
+//	}
+func SetupTmuxSocket() func() {
+	testSocket = fmt.Sprintf("rf-test-%d", os.Getpid())
+	return func() {
+		// Kill the tmux server on our isolated socket.
+		_ = exec.CommandContext(context.Background(), "tmux", "-L", testSocket, "kill-server").Run() //nolint:errcheck // best-effort cleanup
+		testSocket = ""
+	}
+}
+
+// SkipIfNoTmux skips the test if tmux is not installed.
+func SkipIfNoTmux(t *testing.T) {
+	t.Helper()
+
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed, skipping")
+	}
+}
+
+// RealTmux wraps real tmux commands against an isolated socket.
+// Use for integration tests that need to verify tmux actually works.
+type RealTmux struct {
+	socket string
+}
+
+// NewRealTmux creates a RealTmux using the test process's isolated socket.
+// Requires SetupTmuxSocket to have been called in TestMain.
+func NewRealTmux(t *testing.T) *RealTmux {
+	t.Helper()
+	SkipIfNoTmux(t)
+
+	if testSocket == "" {
+		t.Fatal("testutil.SetupTmuxSocket() must be called in TestMain before using NewRealTmux")
+	}
+
+	return &RealTmux{socket: testSocket}
+}
+
+// Run executes a tmux command against the isolated socket.
+func (rt *RealTmux) Run(t *testing.T, args ...string) string {
+	t.Helper()
+
+	fullArgs := append([]string{"-L", rt.socket}, args...)
+	cmd := exec.CommandContext(context.Background(), "tmux", fullArgs...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("tmux %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+
+	return strings.TrimSpace(string(out))
+}
+
+// RunExpectError executes a tmux command expecting failure.
+func (rt *RealTmux) RunExpectError(t *testing.T, args ...string) string {
+	t.Helper()
+
+	fullArgs := append([]string{"-L", rt.socket}, args...)
+	cmd := exec.CommandContext(context.Background(), "tmux", fullArgs...)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected tmux %s to fail, but it succeeded:\n%s", strings.Join(args, " "), out)
+	}
+
+	return strings.TrimSpace(string(out))
+}
+
+// NewSession creates a tmux session and registers cleanup.
+func (rt *RealTmux) NewSession(t *testing.T, name string) {
+	t.Helper()
+
+	rt.Run(t, "new-session", "-d", "-s", name)
+	t.Cleanup(func() {
+		// Best-effort kill — session may already be dead.
+		_ = exec.CommandContext(context.Background(), "tmux", "-L", rt.socket, "kill-session", "-t", name).Run() //nolint:errcheck
+	})
+}
+
+// HasSession checks if a session with the given name exists.
+func (rt *RealTmux) HasSession(t *testing.T, name string) bool {
+	t.Helper()
+
+	fullArgs := []string{"-L", rt.socket, "has-session", "-t", name}
+	cmd := exec.CommandContext(context.Background(), "tmux", fullArgs...)
+	return cmd.Run() == nil
+}
+
+// ListWindows returns the window names for a session.
+func (rt *RealTmux) ListWindows(t *testing.T, session string) []string {
+	t.Helper()
+
+	out := rt.Run(t, "list-windows", "-t", session, "-F", "#{window_name}")
+	if out == "" {
+		return nil
+	}
+	return strings.Split(out, "\n")
+}
+
+// Socket returns the isolated socket name (for passing to subprocess env).
+func (rt *RealTmux) Socket() string {
+	return rt.socket
+}
+
+// RecordingTmux records tmux commands for unit tests where real tmux isn't needed.
+// Use for testing orchestration logic (what commands WOULD be issued) without tmux.
+type RecordingTmux struct {
 	Commands []TmuxCommand
 }
 
@@ -13,33 +138,33 @@ type TmuxCommand struct {
 	Args   []string
 }
 
-// NewFakeTmux creates a new FakeTmux recorder.
-func NewFakeTmux(_ *testing.T) *FakeTmux {
-	return &FakeTmux{}
+// NewRecordingTmux creates a new command recorder for unit tests.
+func NewRecordingTmux() *RecordingTmux {
+	return &RecordingTmux{}
 }
 
 // Record stores a tmux command invocation.
-func (f *FakeTmux) Record(action string, args ...string) {
-	f.Commands = append(f.Commands, TmuxCommand{Action: action, Args: args})
+func (r *RecordingTmux) Record(action string, args ...string) {
+	r.Commands = append(r.Commands, TmuxCommand{Action: action, Args: args})
 }
 
 // CommandCount returns the number of recorded commands.
-func (f *FakeTmux) CommandCount() int {
-	return len(f.Commands)
+func (r *RecordingTmux) CommandCount() int {
+	return len(r.Commands)
 }
 
 // LastCommand returns the most recently recorded command.
 // Returns an empty TmuxCommand if none recorded.
-func (f *FakeTmux) LastCommand() TmuxCommand {
-	if len(f.Commands) == 0 {
+func (r *RecordingTmux) LastCommand() TmuxCommand {
+	if len(r.Commands) == 0 {
 		return TmuxCommand{}
 	}
-	return f.Commands[len(f.Commands)-1]
+	return r.Commands[len(r.Commands)-1]
 }
 
 // HasCommand checks if any recorded command matches the given action.
-func (f *FakeTmux) HasCommand(action string) bool {
-	for _, cmd := range f.Commands {
+func (r *RecordingTmux) HasCommand(action string) bool {
+	for _, cmd := range r.Commands {
 		if cmd.Action == action {
 			return true
 		}

--- a/internal/testutil/tmux_integration_test.go
+++ b/internal/testutil/tmux_integration_test.go
@@ -1,0 +1,75 @@
+//go:build integration
+
+package testutil
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	cleanup := SetupTmuxSocket()
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}
+
+func TestRealTmuxNewSession(t *testing.T) {
+	t.Parallel()
+
+	tm := NewRealTmux(t)
+	sessionName := "rf-test-session-" + t.Name()
+
+	tm.NewSession(t, sessionName)
+
+	if !tm.HasSession(t, sessionName) {
+		t.Fatalf("expected session %q to exist", sessionName)
+	}
+}
+
+func TestRealTmuxNewWindow(t *testing.T) {
+	t.Parallel()
+
+	tm := NewRealTmux(t)
+	sessionName := "rf-test-win-" + t.Name()
+
+	tm.NewSession(t, sessionName)
+	tm.Run(t, "new-window", "-t", sessionName, "-n", "integrator")
+	tm.Run(t, "new-window", "-t", sessionName, "-n", "worker-1")
+
+	windows := tm.ListWindows(t, sessionName)
+
+	var found int
+	for _, w := range windows {
+		if w == "integrator" || w == "worker-1" {
+			found++
+		}
+	}
+
+	if found != 2 {
+		t.Errorf("expected to find integrator and worker-1 windows, got windows: %v", windows)
+	}
+}
+
+func TestRealTmuxSelectWindow(t *testing.T) {
+	t.Parallel()
+
+	tm := NewRealTmux(t)
+	sessionName := "rf-test-sel-" + t.Name()
+
+	tm.NewSession(t, sessionName)
+	tm.Run(t, "new-window", "-t", sessionName, "-n", "target")
+
+	// select-window should not error
+	tm.Run(t, "select-window", "-t", sessionName+":target")
+}
+
+func TestRealTmuxHasSessionReturnsFalseForMissing(t *testing.T) {
+	t.Parallel()
+
+	tm := NewRealTmux(t)
+
+	if tm.HasSession(t, "nonexistent-session-xyz") {
+		t.Error("expected HasSession to return false for nonexistent session")
+	}
+}

--- a/internal/testutil/tmux_test.go
+++ b/internal/testutil/tmux_test.go
@@ -4,44 +4,46 @@ import (
 	"testing"
 )
 
-func TestFakeTmuxRecordsCommands(t *testing.T) {
+// RecordingTmux tests (unit — no real tmux needed)
+
+func TestRecordingTmuxRecordsCommands(t *testing.T) {
 	t.Parallel()
 
-	fake := NewFakeTmux(t)
+	rec := NewRecordingTmux()
 
-	fake.Record("new-session", "-s", "rocket-fuel")
-	fake.Record("new-window", "-t", "rocket-fuel", "-n", "integrator")
+	rec.Record("new-session", "-s", "rocket-fuel")
+	rec.Record("new-window", "-t", "rocket-fuel", "-n", "integrator")
 
-	if fake.CommandCount() != 2 {
-		t.Errorf("expected 2 commands, got %d", fake.CommandCount())
+	if rec.CommandCount() != 2 {
+		t.Errorf("expected 2 commands, got %d", rec.CommandCount())
 	}
 
-	last := fake.LastCommand()
+	last := rec.LastCommand()
 	if last.Action != "new-window" {
 		t.Errorf("expected last action 'new-window', got %q", last.Action)
 	}
 }
 
-func TestFakeTmuxHasCommand(t *testing.T) {
+func TestRecordingTmuxHasCommand(t *testing.T) {
 	t.Parallel()
 
-	fake := NewFakeTmux(t)
-	fake.Record("select-window", "-t", "rocket-fuel:worker-1")
+	rec := NewRecordingTmux()
+	rec.Record("select-window", "-t", "rocket-fuel:worker-1")
 
-	if !fake.HasCommand("select-window") {
+	if !rec.HasCommand("select-window") {
 		t.Error("expected HasCommand('select-window') to be true")
 	}
 
-	if fake.HasCommand("kill-session") {
+	if rec.HasCommand("kill-session") {
 		t.Error("expected HasCommand('kill-session') to be false")
 	}
 }
 
-func TestFakeTmuxLastCommandEmpty(t *testing.T) {
+func TestRecordingTmuxLastCommandEmpty(t *testing.T) {
 	t.Parallel()
 
-	fake := NewFakeTmux(t)
-	last := fake.LastCommand()
+	rec := NewRecordingTmux()
+	last := rec.LastCommand()
 
 	if last.Action != "" {
 		t.Errorf("expected empty action for no commands, got %q", last.Action)


### PR DESCRIPTION
## Summary
Following gastown's testing patterns — test real tools, isolate via configuration:

- **RealTmux**: isolated tmux socket per test process (`-L rf-test-<PID>`)
- **RecordingTmux**: renamed from FakeTmux, for pure unit tests only
- **InitTestRepo / InitTestRepoWithWorktree**: real git repos in `t.TempDir()`
- **Cobra in-process testing**: `SetArgs`/`SetOut` instead of building binary
- Fixed data race in Cobra command tests (sequential for mutations)

## Why
Our original `FakeTmux` was a recorder that didn't prove tmux actually works. For an orchestrator built on tmux and git, that's dangerous. Gastown tests against real tmux with socket isolation — we should too.

## Test plan
- [x] `make test` — unit tests pass with race detector
- [x] `make test-integration` — real tmux integration tests pass
- [x] `make lint` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)