### PR TITLE
feat: `rocket-fuel up` — start tmux-CC session with agent windows

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/drdanmaggs/rocket-fuel/internal/session"
+	"github.com/drdanmaggs/rocket-fuel/internal/tmux"
+	"github.com/spf13/cobra"
+)
+
+var upCmd = &cobra.Command{
+	Use:   "up",
+	Short: "Start the Rocket Fuel tmux session",
+	Long: `Creates a tmux session with Integrator and Dashboard windows,
+then attaches in control mode (-CC) so iTerm2 renders them as native tabs.
+
+If a session already exists, attaches to it.`,
+	RunE: runUp,
+}
+
+func init() {
+	upCmd.Flags().Bool("dry-run", false, "Create session but don't attach (for testing)")
+	rootCmd.AddCommand(upCmd)
+}
+
+func runUp(cmd *cobra.Command, _ []string) error {
+	tm := tmux.New()
+	sessionName := session.DefaultSessionName
+
+	created, err := session.Setup(tm, sessionName)
+	if err != nil {
+		return fmt.Errorf("session setup failed: %w", err)
+	}
+
+	if created {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Created session %q with windows: integrator, dashboard\n", sessionName)
+	} else {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Attaching to existing session %q\n", sessionName)
+	}
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Dry run — not attaching.")
+		return nil
+	}
+
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Attaching with tmux -CC (iTerm2 control mode)...")
+
+	// AttachCC replaces this process via exec — does not return on success.
+	if err := tm.AttachCC(sessionName); err != nil {
+		return fmt.Errorf("failed to attach: %w", err)
+	}
+
+	return nil
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1,0 +1,41 @@
+// Package session manages the Rocket Fuel tmux session lifecycle.
+package session
+
+import (
+	"fmt"
+
+	"github.com/drdanmaggs/rocket-fuel/internal/tmux"
+)
+
+// DefaultSessionName is the tmux session name used by Rocket Fuel.
+const DefaultSessionName = "rocket-fuel"
+
+// Windows defines the tmux windows created for a Rocket Fuel session.
+var Windows = []string{"integrator", "dashboard"}
+
+// Setup creates the Rocket Fuel tmux session with all agent windows.
+// Returns true if a new session was created, false if one already existed.
+func Setup(tm tmux.Runner, sessionName string) (bool, error) {
+	if tm.HasSession(sessionName) {
+		return false, nil
+	}
+
+	if err := tm.NewSession(sessionName); err != nil {
+		return false, fmt.Errorf("create session: %w", err)
+	}
+
+	for _, win := range Windows {
+		if err := tm.NewWindow(sessionName, win); err != nil {
+			// Clean up on partial failure.
+			_ = tm.KillSession(sessionName)
+			return false, fmt.Errorf("create window %q: %w", win, err)
+		}
+	}
+
+	// Switch back to the first window (integrator).
+	if err := tm.SelectWindow(sessionName, Windows[0]); err != nil {
+		return true, fmt.Errorf("select window: %w", err)
+	}
+
+	return true, nil
+}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -1,0 +1,136 @@
+package session
+
+import (
+	"testing"
+)
+
+// mockRunner is a test double for tmux.Runner that records calls.
+type mockRunner struct {
+	sessions map[string]bool
+	windows  map[string][]string
+	calls    []string
+	failOn   string // if set, return error when this method is called
+}
+
+func newMockRunner() *mockRunner {
+	return &mockRunner{
+		sessions: make(map[string]bool),
+		windows:  make(map[string][]string),
+	}
+}
+
+func (m *mockRunner) HasSession(name string) bool {
+	m.calls = append(m.calls, "HasSession:"+name)
+	return m.sessions[name]
+}
+
+func (m *mockRunner) NewSession(name string) error {
+	m.calls = append(m.calls, "NewSession:"+name)
+	if m.failOn == "NewSession" {
+		return errMock
+	}
+	m.sessions[name] = true
+	return nil
+}
+
+func (m *mockRunner) NewWindow(session, name string) error {
+	m.calls = append(m.calls, "NewWindow:"+session+":"+name)
+	if m.failOn == "NewWindow" {
+		return errMock
+	}
+	m.windows[session] = append(m.windows[session], name)
+	return nil
+}
+
+func (m *mockRunner) SelectWindow(session, window string) error {
+	m.calls = append(m.calls, "SelectWindow:"+session+":"+window)
+	if m.failOn == "SelectWindow" {
+		return errMock
+	}
+	return nil
+}
+
+func (m *mockRunner) KillSession(name string) error {
+	m.calls = append(m.calls, "KillSession:"+name)
+	delete(m.sessions, name)
+	return nil
+}
+
+func (m *mockRunner) AttachCC(_ string) error {
+	// Not called by Setup — AttachCC is handled by the cmd layer.
+	return nil
+}
+
+var errMock = &mockError{}
+
+type mockError struct{}
+
+func (e *mockError) Error() string { return "mock error" }
+
+func TestSetupCreatesSessionAndWindows(t *testing.T) {
+	t.Parallel()
+
+	tm := newMockRunner()
+
+	created, err := Setup(tm, "test-session")
+	if err != nil {
+		t.Fatalf("Setup failed: %v", err)
+	}
+
+	if !created {
+		t.Error("expected Setup to report session was created")
+	}
+
+	if !tm.sessions["test-session"] {
+		t.Error("expected session to exist")
+	}
+
+	windows := tm.windows["test-session"]
+	if len(windows) != len(Windows) {
+		t.Errorf("expected %d windows, got %d", len(Windows), len(windows))
+	}
+
+	for i, expected := range Windows {
+		if windows[i] != expected {
+			t.Errorf("window %d: expected %q, got %q", i, expected, windows[i])
+		}
+	}
+}
+
+func TestSetupIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	tm := newMockRunner()
+	tm.sessions["existing"] = true
+
+	created, err := Setup(tm, "existing")
+	if err != nil {
+		t.Fatalf("Setup failed: %v", err)
+	}
+
+	if created {
+		t.Error("expected Setup to report session already existed")
+	}
+
+	// Should not have created any windows.
+	if len(tm.windows["existing"]) != 0 {
+		t.Errorf("expected no windows created, got %v", tm.windows["existing"])
+	}
+}
+
+func TestSetupCleansUpOnWindowFailure(t *testing.T) {
+	t.Parallel()
+
+	tm := newMockRunner()
+	tm.failOn = "NewWindow"
+
+	_, err := Setup(tm, "fail-session")
+	if err == nil {
+		t.Fatal("expected Setup to fail when NewWindow fails")
+	}
+
+	// Session should have been killed (cleanup on partial failure).
+	if tm.sessions["fail-session"] {
+		t.Error("expected session to be cleaned up after window creation failure")
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1,0 +1,97 @@
+// Package tmux provides an interface and implementation for tmux operations.
+package tmux
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+)
+
+// Runner defines the interface for tmux operations.
+// Real implementation calls tmux CLI; test doubles record commands.
+type Runner interface {
+	HasSession(name string) bool
+	NewSession(name string) error
+	NewWindow(session, name string) error
+	SelectWindow(session, window string) error
+	KillSession(name string) error
+	AttachCC(session string) error
+}
+
+// CLI implements Runner by calling the real tmux binary.
+type CLI struct {
+	socket string // optional: use -L socket for isolation
+}
+
+// New creates a CLI runner using the default tmux socket.
+func New() *CLI {
+	return &CLI{}
+}
+
+// NewWithSocket creates a CLI runner using a specific tmux socket.
+// Used for testing (isolated socket) or multi-instance scenarios.
+func NewWithSocket(socket string) *CLI {
+	return &CLI{socket: socket}
+}
+
+// HasSession checks if a tmux session with the given name exists.
+func (c *CLI) HasSession(name string) bool {
+	return c.run("has-session", "-t", name) == nil
+}
+
+// NewSession creates a new detached tmux session.
+func (c *CLI) NewSession(name string) error {
+	return c.run("new-session", "-d", "-s", name)
+}
+
+// NewWindow creates a new window in the given session.
+func (c *CLI) NewWindow(session, name string) error {
+	return c.run("new-window", "-t", session, "-n", name)
+}
+
+// SelectWindow switches to the named window in the session.
+func (c *CLI) SelectWindow(session, window string) error {
+	return c.run("select-window", "-t", session+":"+window)
+}
+
+// KillSession destroys the named session.
+func (c *CLI) KillSession(name string) error {
+	return c.run("kill-session", "-t", name)
+}
+
+// AttachCC replaces the current process with tmux -CC attach.
+// This hands control to tmux in control mode — iTerm2 will render
+// tmux windows as native tabs.
+//
+// This function does not return on success (it execs).
+func (c *CLI) AttachCC(session string) error {
+	tmuxPath, err := exec.LookPath("tmux")
+	if err != nil {
+		return fmt.Errorf("tmux not found: %w", err)
+	}
+
+	args := []string{"tmux"}
+	if c.socket != "" {
+		args = append(args, "-L", c.socket)
+	}
+	args = append(args, "-CC", "attach", "-t", session)
+
+	// Replace this process with tmux — does not return on success.
+	return syscall.Exec(tmuxPath, args, os.Environ())
+}
+
+func (c *CLI) run(args ...string) error {
+	fullArgs := args
+	if c.socket != "" {
+		fullArgs = append([]string{"-L", c.socket}, args...)
+	}
+
+	cmd := exec.CommandContext(context.Background(), "tmux", fullArgs...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("tmux %s: %w\n%s", strings.Join(args, " "), err, out)
+	}
+	return nil
+}

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -1,0 +1,105 @@
+//go:build integration
+
+package tmux
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+var testSocket string
+
+func TestMain(m *testing.M) {
+	testSocket = fmt.Sprintf("rf-tmux-test-%d", os.Getpid())
+	code := m.Run()
+	// Best-effort cleanup of the isolated tmux server.
+	cli := NewWithSocket(testSocket)
+	_ = cli.run("kill-server")
+	os.Exit(code)
+}
+
+func TestNewSessionAndHasSession(t *testing.T) {
+	t.Parallel()
+
+	cli := NewWithSocket(testSocket)
+	name := "rf-test-" + t.Name()
+
+	if err := cli.NewSession(name); err != nil {
+		t.Fatalf("NewSession failed: %v", err)
+	}
+	t.Cleanup(func() { _ = cli.KillSession(name) })
+
+	if !cli.HasSession(name) {
+		t.Fatalf("expected session %q to exist", name)
+	}
+}
+
+func TestHasSessionReturnsFalseForMissing(t *testing.T) {
+	t.Parallel()
+
+	cli := NewWithSocket(testSocket)
+
+	if cli.HasSession("nonexistent-session-xyz") {
+		t.Error("expected HasSession to return false for nonexistent session")
+	}
+}
+
+func TestNewWindowCreatesWindow(t *testing.T) {
+	t.Parallel()
+
+	cli := NewWithSocket(testSocket)
+	session := "rf-test-win-" + t.Name()
+
+	if err := cli.NewSession(session); err != nil {
+		t.Fatalf("NewSession failed: %v", err)
+	}
+	t.Cleanup(func() { _ = cli.KillSession(session) })
+
+	if err := cli.NewWindow(session, "integrator"); err != nil {
+		t.Fatalf("NewWindow failed: %v", err)
+	}
+
+	if err := cli.NewWindow(session, "dashboard"); err != nil {
+		t.Fatalf("NewWindow failed: %v", err)
+	}
+}
+
+func TestSelectWindow(t *testing.T) {
+	t.Parallel()
+
+	cli := NewWithSocket(testSocket)
+	session := "rf-test-sel-" + t.Name()
+
+	if err := cli.NewSession(session); err != nil {
+		t.Fatalf("NewSession failed: %v", err)
+	}
+	t.Cleanup(func() { _ = cli.KillSession(session) })
+
+	if err := cli.NewWindow(session, "target"); err != nil {
+		t.Fatalf("NewWindow failed: %v", err)
+	}
+
+	if err := cli.SelectWindow(session, "target"); err != nil {
+		t.Fatalf("SelectWindow failed: %v", err)
+	}
+}
+
+func TestKillSession(t *testing.T) {
+	t.Parallel()
+
+	cli := NewWithSocket(testSocket)
+	session := "rf-test-kill-" + t.Name()
+
+	if err := cli.NewSession(session); err != nil {
+		t.Fatalf("NewSession failed: %v", err)
+	}
+
+	if err := cli.KillSession(session); err != nil {
+		t.Fatalf("KillSession failed: %v", err)
+	}
+
+	if cli.HasSession(session) {
+		t.Error("expected session to be gone after KillSession")
+	}
+}


### PR DESCRIPTION
## Summary
- `internal/tmux` package: `Runner` interface + `CLI` implementation with socket isolation
- `internal/session` package: creates session with integrator + dashboard windows
- `rocket-fuel up` command: creates session, attaches with tmux -CC for iTerm2
- `--dry-run` flag for testing without attaching
- Idempotent: if session exists, attaches to it

## Test plan
- [x] Unit tests: session setup logic (mock runner), idempotency, partial failure cleanup
- [x] Integration tests: real tmux with isolated socket — new session, new window, select window, kill session
- [x] `make lint` passes
- [x] `make test` + `make test-integration` pass

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)