### PR TITLE
feat: `rocket-fuel work <issue>` — spawn worker on GitHub issue

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1,0 +1,154 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/drdanmaggs/rocket-fuel/internal/session"
+	"github.com/drdanmaggs/rocket-fuel/internal/tmux"
+	"github.com/drdanmaggs/rocket-fuel/internal/worker"
+	"github.com/spf13/cobra"
+)
+
+var workCmd = &cobra.Command{
+	Use:   "work <issue-number-or-url>",
+	Short: "Spawn a worker on a GitHub issue",
+	Long: `Creates a git worktree, opens a new tmux window, and launches
+Claude Code to work on the specified GitHub issue.
+
+The issue is read from GitHub and routed to the appropriate skill
+based on its labels (workflow:tdd, workflow:bug-fix, etc.).`,
+	Args: cobra.ExactArgs(1),
+	RunE: runWork,
+}
+
+func init() {
+	rootCmd.AddCommand(workCmd)
+}
+
+func runWork(cmd *cobra.Command, args []string) error {
+	issueRef := args[0]
+
+	// Parse issue number from URL or plain number.
+	issueNumber, err := parseIssueRef(issueRef)
+	if err != nil {
+		return err
+	}
+
+	// Fetch issue from GitHub.
+	issue, err := fetchIssue(issueNumber)
+	if err != nil {
+		return fmt.Errorf("fetch issue: %w", err)
+	}
+
+	// Get repo root.
+	repoDir, err := gitRepoRoot()
+	if err != nil {
+		return fmt.Errorf("find repo root: %w", err)
+	}
+
+	// Ensure worktrees directory exists.
+	worktreesDir := repoDir + "/.worktrees"
+	if err := os.MkdirAll(worktreesDir, 0o755); err != nil {
+		return fmt.Errorf("create .worktrees dir: %w", err)
+	}
+
+	tm := tmux.New()
+	cfg := worker.SpawnConfig{
+		RepoDir:     repoDir,
+		SessionName: session.DefaultSessionName,
+	}
+
+	if err := worker.Spawn(tm, cfg, *issue); err != nil {
+		return fmt.Errorf("spawn worker: %w", err)
+	}
+
+	skill := skillFromLabels(issue.Labels)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Spawned worker-%d on issue #%d: %s (skill: %s)\n",
+		issue.Number, issue.Number, issue.Title, skill)
+
+	return nil
+}
+
+func parseIssueRef(ref string) (int, error) {
+	// Handle URLs like https://github.com/owner/repo/issues/42
+	if strings.Contains(ref, "/issues/") {
+		parts := strings.Split(ref, "/issues/")
+		if len(parts) == 2 {
+			ref = parts[1]
+		}
+	}
+
+	// Strip leading #
+	ref = strings.TrimPrefix(ref, "#")
+
+	n, err := strconv.Atoi(ref)
+	if err != nil {
+		return 0, fmt.Errorf("invalid issue reference %q: must be a number or GitHub URL", ref)
+	}
+	return n, nil
+}
+
+type ghIssue struct {
+	Number int       `json:"number"`
+	Title  string    `json:"title"`
+	Body   string    `json:"body"`
+	Labels []ghLabel `json:"labels"`
+}
+
+type ghLabel struct {
+	Name string `json:"name"`
+}
+
+func fetchIssue(number int) (*worker.Issue, error) {
+	out, err := exec.CommandContext(context.Background(), "gh", "issue", "view", strconv.Itoa(number), "--json", "number,title,body,labels").Output()
+	if err != nil {
+		return nil, fmt.Errorf("gh issue view: %w", err)
+	}
+
+	var gh ghIssue
+	if err := json.Unmarshal(out, &gh); err != nil {
+		return nil, fmt.Errorf("parse issue JSON: %w", err)
+	}
+
+	labels := make([]string, len(gh.Labels))
+	for i, l := range gh.Labels {
+		labels[i] = l.Name
+	}
+
+	return &worker.Issue{
+		Number: gh.Number,
+		Title:  gh.Title,
+		Body:   gh.Body,
+		Labels: labels,
+	}, nil
+}
+
+func gitRepoRoot() (string, error) {
+	out, err := exec.CommandContext(context.Background(), "git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", fmt.Errorf("not in a git repo: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func skillFromLabels(labels []string) string {
+	for _, label := range labels {
+		switch label {
+		case "workflow:tdd":
+			return "/tdd"
+		case "workflow:bug-fix":
+			return "/bug-fix"
+		case "workflow:epc":
+			return "/epc"
+		case "workflow:issue-scope":
+			return "/issue-scope"
+		}
+	}
+	return "/epc"
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -83,6 +83,11 @@ func (c *CLI) AttachCC(session string) error {
 	return syscall.Exec(tmuxPath, args, os.Environ())
 }
 
+// SendKeys sends keystrokes to a specific window in a session.
+func (c *CLI) SendKeys(session, window, keys string) error {
+	return c.run("send-keys", "-t", session+":"+window, keys, "Enter")
+}
+
 func (c *CLI) run(args ...string) error {
 	fullArgs := args
 	if c.socket != "" {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -1,0 +1,115 @@
+// Package worker manages spawning and tracking Claude Code workers in git worktrees.
+package worker
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/drdanmaggs/rocket-fuel/internal/tmux"
+)
+
+// Issue holds the GitHub issue context needed to spawn a worker.
+type Issue struct {
+	Number int
+	Title  string
+	Body   string
+	Labels []string
+}
+
+// SpawnConfig holds configuration for spawning a worker.
+type SpawnConfig struct {
+	RepoDir     string // root of the git repo
+	SessionName string // tmux session to create window in
+}
+
+// Spawn creates a git worktree, tmux window, and launches Claude Code for an issue.
+func Spawn(tm tmux.Runner, cfg SpawnConfig, issue Issue) error {
+	branchName := fmt.Sprintf("rf/issue-%d", issue.Number)
+	worktreeDir := filepath.Join(cfg.RepoDir, ".worktrees", fmt.Sprintf("worker-%d", issue.Number))
+	windowName := fmt.Sprintf("worker-%d", issue.Number)
+
+	// Create git worktree.
+	if err := createWorktree(cfg.RepoDir, worktreeDir, branchName); err != nil {
+		return fmt.Errorf("create worktree: %w", err)
+	}
+
+	// Create tmux window.
+	if err := tm.NewWindow(cfg.SessionName, windowName); err != nil {
+		return fmt.Errorf("create window: %w", err)
+	}
+
+	// Send commands to the new window: cd into worktree and launch claude.
+	skill := routeSkill(issue.Labels)
+	prompt := buildPrompt(issue, skill)
+
+	sendKeys := fmt.Sprintf("cd %s && claude --prompt %s", worktreeDir, shellQuote(prompt))
+	if err := tmuxSendKeys(tm, cfg.SessionName, windowName, sendKeys); err != nil {
+		return fmt.Errorf("send keys: %w", err)
+	}
+
+	return nil
+}
+
+// routeSkill determines which skill to use based on issue labels.
+func routeSkill(labels []string) string {
+	for _, label := range labels {
+		switch label {
+		case "workflow:tdd":
+			return "/tdd"
+		case "workflow:bug-fix":
+			return "/bug-fix"
+		case "workflow:epc":
+			return "/epc"
+		case "workflow:issue-scope":
+			return "/issue-scope"
+		}
+	}
+	return "/epc" // default skill
+}
+
+// buildPrompt creates the prompt string for Claude Code.
+func buildPrompt(issue Issue, skill string) string {
+	var b strings.Builder
+
+	_, _ = fmt.Fprintf(&b, "You are a Rocket Fuel worker. Your task is issue #%d: %s\n\n", issue.Number, issue.Title)
+
+	if issue.Body != "" {
+		_, _ = fmt.Fprintf(&b, "Issue description:\n%s\n\n", issue.Body)
+	}
+
+	_, _ = fmt.Fprintf(&b, "Execute this using the %s skill. When done, create a PR with `gh pr create`.\n", skill)
+	_, _ = fmt.Fprintf(&b, "Stay focused on this single issue. Don't scope-creep.")
+
+	return b.String()
+}
+
+func createWorktree(repoDir, worktreeDir, branchName string) error {
+	cmd := exec.CommandContext(
+		context.Background(),
+		"git", "worktree", "add", "-b", branchName, worktreeDir,
+	)
+	cmd.Dir = repoDir
+
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("%w\n%s", err, out)
+	}
+	return nil
+}
+
+func tmuxSendKeys(tm tmux.Runner, session, window, keys string) error {
+	// SendKeys isn't on the Runner interface yet — use the CLI directly for now.
+	cli, ok := tm.(*tmux.CLI)
+	if !ok {
+		// For testing, this is a no-op — we verify the worktree and window creation.
+		return nil
+	}
+	return cli.SendKeys(session, window, keys)
+}
+
+func shellQuote(s string) string {
+	// Single-quote the string, escaping any existing single quotes.
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -1,0 +1,116 @@
+package worker
+
+import (
+	"testing"
+)
+
+func TestRouteSkillFromLabels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		labels   []string
+		expected string
+	}{
+		{"tdd label", []string{"workflow:tdd"}, "/tdd"},
+		{"bug-fix label", []string{"workflow:bug-fix"}, "/bug-fix"},
+		{"epc label", []string{"workflow:epc"}, "/epc"},
+		{"issue-scope label", []string{"workflow:issue-scope"}, "/issue-scope"},
+		{"no workflow label", []string{"enhancement", "v0.1"}, "/epc"},
+		{"empty labels", nil, "/epc"},
+		{"multiple labels picks first workflow", []string{"v0.1", "workflow:tdd", "workflow:bug-fix"}, "/tdd"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := routeSkill(tt.labels)
+			if got != tt.expected {
+				t.Errorf("routeSkill(%v) = %q, want %q", tt.labels, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBuildPrompt(t *testing.T) {
+	t.Parallel()
+
+	issue := Issue{
+		Number: 42,
+		Title:  "Add user login",
+		Body:   "Implement OAuth2 flow",
+		Labels: []string{"workflow:tdd"},
+	}
+
+	prompt := buildPrompt(issue, "/tdd")
+
+	if got := prompt; got == "" {
+		t.Fatal("expected non-empty prompt")
+	}
+
+	checks := []string{
+		"#42",
+		"Add user login",
+		"OAuth2 flow",
+		"/tdd",
+		"gh pr create",
+	}
+
+	for _, check := range checks {
+		if !contains(prompt, check) {
+			t.Errorf("expected prompt to contain %q", check)
+		}
+	}
+}
+
+func TestBuildPromptWithoutBody(t *testing.T) {
+	t.Parallel()
+
+	issue := Issue{
+		Number: 1,
+		Title:  "Simple fix",
+	}
+
+	prompt := buildPrompt(issue, "/bug-fix")
+
+	if contains(prompt, "Issue description") {
+		t.Error("expected no 'Issue description' section when body is empty")
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"hello", "'hello'"},
+		{"it's", "'it'\\''s'"},
+		{"", "''"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			got := shellQuote(tt.input)
+			if got != tt.expected {
+				t.Errorf("shellQuote(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) > 0 && len(substr) > 0 && // avoid false positives on empty strings
+		indexOf(s, substr) >= 0
+}
+
+func indexOf(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
## Summary
- `rocket-fuel work <issue-number-or-url>` spawns a Claude Code worker
- Creates git worktree at `.worktrees/worker-<N>` on branch `rf/issue-<N>`
- Fetches issue from GitHub, routes to skill based on labels
- Opens new tmux window and launches Claude Code with issue context

**Depends on:** #24 (`rocket-fuel up`) — merge that first.

## Test plan
- [x] Table-driven tests for skill routing (7 cases)
- [x] Prompt building includes issue number, title, body, skill
- [x] Shell quoting handles single quotes
- [x] `make lint` — 0 issues
- [x] `make test` passes

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)