### PR TITLE
feat: `rocket-fuel status` — dashboard status display

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/drdanmaggs/rocket-fuel/internal/session"
+	"github.com/drdanmaggs/rocket-fuel/internal/status"
+	"github.com/drdanmaggs/rocket-fuel/internal/tmux"
+	"github.com/spf13/cobra"
+)
+
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show current Rocket Fuel status",
+	Long:  `Displays session state, active workers, branches, and PR status.`,
+	RunE:  runStatus,
+}
+
+func init() {
+	rootCmd.AddCommand(statusCmd)
+}
+
+func runStatus(cmd *cobra.Command, _ []string) error {
+	repoDir, err := statusRepoRoot()
+	if err != nil {
+		return fmt.Errorf("find repo root: %w", err)
+	}
+
+	tm := tmux.New()
+	sessionName := session.DefaultSessionName
+
+	s, err := status.Gather(tm, sessionName, repoDir)
+	if err != nil {
+		return fmt.Errorf("gather status: %w", err)
+	}
+
+	_, _ = fmt.Fprint(cmd.OutOrStdout(), status.Format(s))
+	return nil
+}
+
+func statusRepoRoot() (string, error) {
+	out, err := exec.CommandContext(context.Background(), "git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", fmt.Errorf("not in a git repo: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -1,0 +1,132 @@
+// Package status provides a summary of the current Rocket Fuel state.
+package status
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/drdanmaggs/rocket-fuel/internal/tmux"
+)
+
+// Summary holds the current state of Rocket Fuel.
+type Summary struct {
+	SessionActive bool
+	Workers       []WorkerStatus
+	RepoDir       string
+}
+
+// WorkerStatus describes a single worker's state.
+type WorkerStatus struct {
+	Name       string
+	WindowOpen bool
+	Branch     string
+	HasPR      bool
+}
+
+// Gather collects the current state from tmux, git, and GitHub.
+func Gather(tm tmux.Runner, sessionName, repoDir string) (*Summary, error) {
+	s := &Summary{
+		SessionActive: tm.HasSession(sessionName),
+		RepoDir:       repoDir,
+	}
+
+	worktreesDir := filepath.Join(repoDir, ".worktrees")
+	entries, err := os.ReadDir(worktreesDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return s, nil
+		}
+		return nil, fmt.Errorf("read worktrees: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		worktreeDir := filepath.Join(worktreesDir, name)
+
+		ws := WorkerStatus{
+			Name:       name,
+			WindowOpen: s.SessionActive && tm.SelectWindow(sessionName, name) == nil,
+			Branch:     worktreeBranch(worktreeDir),
+		}
+
+		if ws.Branch != "" {
+			ws.HasPR = branchHasPR(ws.Branch)
+		}
+
+		s.Workers = append(s.Workers, ws)
+	}
+
+	return s, nil
+}
+
+// Format renders the summary as a human-readable string.
+func Format(s *Summary) string {
+	var b strings.Builder
+
+	_, _ = fmt.Fprintln(&b, "=== Rocket Fuel Status ===")
+	_, _ = fmt.Fprintln(&b)
+
+	if s.SessionActive {
+		_, _ = fmt.Fprintln(&b, "Session: ACTIVE")
+	} else {
+		_, _ = fmt.Fprintln(&b, "Session: INACTIVE")
+	}
+
+	_, _ = fmt.Fprintln(&b)
+
+	if len(s.Workers) == 0 {
+		_, _ = fmt.Fprintln(&b, "Workers: none")
+	} else {
+		_, _ = fmt.Fprintf(&b, "Workers: %d\n", len(s.Workers))
+		for _, w := range s.Workers {
+			state := "done"
+			if w.WindowOpen {
+				state = "active"
+			}
+
+			pr := ""
+			if w.HasPR {
+				pr = " [PR open]"
+			}
+
+			_, _ = fmt.Fprintf(&b, "  %s  %-10s  %s%s\n", w.Name, "("+state+")", w.Branch, pr)
+		}
+	}
+
+	return b.String()
+}
+
+func worktreeBranch(dir string) string {
+	cmd := exec.CommandContext(context.Background(), "git", "branch", "--show-current")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func branchHasPR(branch string) bool {
+	cmd := exec.CommandContext(context.Background(),
+		"gh", "pr", "list", "--head", branch, "--json", "number", "--limit", "1",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+
+	var prs []json.RawMessage
+	if err := json.Unmarshal(out, &prs); err != nil {
+		return false
+	}
+	return len(prs) > 0
+}

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -1,0 +1,141 @@
+package status
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type mockRunner struct {
+	sessions map[string]bool
+	windows  map[string]map[string]bool
+}
+
+func newMockRunner() *mockRunner {
+	return &mockRunner{
+		sessions: make(map[string]bool),
+		windows:  make(map[string]map[string]bool),
+	}
+}
+
+func (m *mockRunner) HasSession(name string) bool { return m.sessions[name] }
+func (m *mockRunner) NewSession(_ string) error   { return nil }
+func (m *mockRunner) NewWindow(_, _ string) error { return nil }
+func (m *mockRunner) KillSession(_ string) error  { return nil }
+func (m *mockRunner) AttachCC(_ string) error     { return nil }
+
+func (m *mockRunner) SelectWindow(session, window string) error {
+	if m.windows[session] != nil && m.windows[session][window] {
+		return nil
+	}
+	return &mockErr{}
+}
+
+type mockErr struct{}
+
+func (e *mockErr) Error() string { return "not found" }
+
+func TestGatherWithNoWorkers(t *testing.T) {
+	t.Parallel()
+
+	tm := newMockRunner()
+	tm.sessions["rocket-fuel"] = true
+	repoDir := t.TempDir()
+
+	s, err := Gather(tm, "rocket-fuel", repoDir)
+	if err != nil {
+		t.Fatalf("Gather failed: %v", err)
+	}
+
+	if !s.SessionActive {
+		t.Error("expected session to be active")
+	}
+
+	if len(s.Workers) != 0 {
+		t.Errorf("expected 0 workers, got %d", len(s.Workers))
+	}
+}
+
+func TestGatherWithWorkers(t *testing.T) {
+	t.Parallel()
+
+	repoDir := t.TempDir()
+	worktreesDir := filepath.Join(repoDir, ".worktrees")
+
+	// Create two worker directories.
+	for _, name := range []string{"worker-1", "worker-2"} {
+		if err := os.MkdirAll(filepath.Join(worktreesDir, name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tm := newMockRunner()
+	tm.sessions["rocket-fuel"] = true
+	tm.windows["rocket-fuel"] = map[string]bool{"worker-1": true}
+
+	s, err := Gather(tm, "rocket-fuel", repoDir)
+	if err != nil {
+		t.Fatalf("Gather failed: %v", err)
+	}
+
+	if len(s.Workers) != 2 {
+		t.Fatalf("expected 2 workers, got %d", len(s.Workers))
+	}
+
+	// worker-1 should be active (window exists).
+	if !s.Workers[0].WindowOpen {
+		t.Error("expected worker-1 window to be open")
+	}
+
+	// worker-2 should be done (no window).
+	if s.Workers[1].WindowOpen {
+		t.Error("expected worker-2 window to be closed")
+	}
+}
+
+func TestGatherWithInactiveSession(t *testing.T) {
+	t.Parallel()
+
+	tm := newMockRunner()
+	repoDir := t.TempDir()
+
+	s, err := Gather(tm, "rocket-fuel", repoDir)
+	if err != nil {
+		t.Fatalf("Gather failed: %v", err)
+	}
+
+	if s.SessionActive {
+		t.Error("expected session to be inactive")
+	}
+}
+
+func TestFormatOutput(t *testing.T) {
+	t.Parallel()
+
+	s := &Summary{
+		SessionActive: true,
+		Workers: []WorkerStatus{
+			{Name: "worker-1", WindowOpen: true, Branch: "rf/issue-1"},
+			{Name: "worker-2", WindowOpen: false, Branch: "rf/issue-2", HasPR: true},
+		},
+	}
+
+	out := Format(s)
+
+	checks := []string{
+		"Session: ACTIVE",
+		"Workers: 2",
+		"worker-1",
+		"(active)",
+		"worker-2",
+		"(done)",
+		"[PR open]",
+	}
+
+	for _, check := range checks {
+		if !strings.Contains(out, check) {
+			t.Errorf("expected output to contain %q\n\nGot:\n%s", check, out)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `rocket-fuel status` shows session state, active workers, branches, and PR status
- Gathers from tmux (session/window state), git (worktree branches), gh (PR existence)
- Clean terminal output suitable for `watch -n 30 rocket-fuel status` in the dashboard window

**Depends on:** #24 (`up`)

## Test plan
- [x] Gather with no workers
- [x] Gather with active + completed workers
- [x] Gather with inactive session
- [x] Format output contains expected fields
- [x] `make lint` — 0 issues
- [x] `make test` passes

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)