### PR TITLE
feat: GitHub Project board integration

### DIFF
--- a/cmd/project.go
+++ b/cmd/project.go
@@ -1,0 +1,148 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/drdanmaggs/rocket-fuel/internal/project"
+	"github.com/spf13/cobra"
+)
+
+var projectCmd = &cobra.Command{
+	Use:   "project",
+	Short: "Manage the linked GitHub Project",
+	Long:  `Link a GitHub Project board and view its status. The Integrator uses this as its brain.`,
+}
+
+var projectLinkCmd = &cobra.Command{
+	Use:   "link <project-url-or-number>",
+	Short: "Link a GitHub Project to this session",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runProjectLink,
+}
+
+var projectStatusCmd = &cobra.Command{
+	Use:   "board",
+	Short: "Show the project board status",
+	RunE:  runProjectBoard,
+}
+
+func init() {
+	projectCmd.AddCommand(projectLinkCmd)
+	projectCmd.AddCommand(projectStatusCmd)
+	rootCmd.AddCommand(projectCmd)
+}
+
+func runProjectLink(cmd *cobra.Command, args []string) error {
+	ref := args[0]
+
+	owner, number, err := parseProjectRef(ref)
+	if err != nil {
+		return err
+	}
+
+	cfg := project.Config{
+		ProjectNumber: number,
+		Owner:         owner,
+	}
+
+	if err := saveProjectConfig(cfg); err != nil {
+		return fmt.Errorf("save config: %w", err)
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Linked project #%d (owner: %s)\n", number, owner)
+	return nil
+}
+
+func runProjectBoard(cmd *cobra.Command, _ []string) error {
+	cfg, err := loadProjectConfig()
+	if err != nil {
+		return fmt.Errorf("no project linked: %w\nRun: rocket-fuel project link <project-url>", err)
+	}
+
+	board, err := project.FetchBoard(cfg.Owner, cfg.ProjectNumber)
+	if err != nil {
+		return fmt.Errorf("fetch board: %w", err)
+	}
+
+	_, _ = fmt.Fprint(cmd.OutOrStdout(), project.FormatBoard(board))
+	return nil
+}
+
+func parseProjectRef(ref string) (string, int, error) {
+	// Handle URLs like https://github.com/users/owner/projects/1
+	// or https://github.com/orgs/owner/projects/1
+	if strings.Contains(ref, "/projects/") {
+		parts := strings.Split(ref, "/projects/")
+		if len(parts) == 2 {
+			numStr := strings.TrimRight(parts[1], "/")
+			num, err := strconv.Atoi(numStr)
+			if err != nil {
+				return "", 0, fmt.Errorf("invalid project number in URL: %q", numStr)
+			}
+
+			// Extract owner from the path.
+			pathParts := strings.Split(parts[0], "/")
+			owner := pathParts[len(pathParts)-1]
+			return owner, num, nil
+		}
+	}
+
+	return "", 0, fmt.Errorf("invalid project reference %q: use a GitHub Project URL (e.g., https://github.com/users/owner/projects/1)", ref)
+}
+
+func configDir() (string, error) {
+	repoDir, err := projectRepoRoot()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(repoDir, ".rocket-fuel")
+	return dir, os.MkdirAll(dir, 0o755)
+}
+
+func saveProjectConfig(cfg project.Config) error {
+	dir, err := configDir()
+	if err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(dir, "project.json"), data, 0o644)
+}
+
+func loadProjectConfig() (*project.Config, error) {
+	dir, err := configDir()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "project.json"))
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg project.Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+
+	return &cfg, nil
+}
+
+func projectRepoRoot() (string, error) {
+	out, err := exec.CommandContext(context.Background(), "git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", fmt.Errorf("not in a git repo: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -1,0 +1,141 @@
+// Package project provides GitHub Project board integration for the Integrator.
+package project
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// Config stores the linked GitHub Project reference.
+type Config struct {
+	ProjectNumber int    `json:"project_number"`
+	Owner         string `json:"owner"`
+}
+
+// Item represents an issue on the project board.
+type Item struct {
+	ID     string
+	Title  string
+	Number int
+	Status string
+	Labels []string
+}
+
+// BoardSummary holds the state of the project board by column.
+type BoardSummary struct {
+	ProjectTitle string
+	Columns      map[string][]Item
+}
+
+// FetchBoard reads the current state of a GitHub Project board.
+func FetchBoard(owner string, projectNumber int) (*BoardSummary, error) {
+	out, err := exec.CommandContext(context.Background(),
+		"gh", "project", "item-list", strconv.Itoa(projectNumber),
+		"--owner", owner,
+		"--format", "json",
+		"--limit", "200",
+	).Output()
+	if err != nil {
+		return nil, fmt.Errorf("gh project item-list: %w", err)
+	}
+
+	var raw struct {
+		Items []struct {
+			ID      string `json:"id"`
+			Title   string `json:"title"`
+			Status  string `json:"status"`
+			Content struct {
+				Number int      `json:"number"`
+				Labels []string `json:"labels"`
+			} `json:"content"`
+		} `json:"items"`
+		TotalCount int `json:"totalCount"`
+	}
+
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, fmt.Errorf("parse project items: %w", err)
+	}
+
+	summary := &BoardSummary{
+		Columns: make(map[string][]Item),
+	}
+
+	for _, item := range raw.Items {
+		status := item.Status
+		if status == "" {
+			status = "No Status"
+		}
+
+		summary.Columns[status] = append(summary.Columns[status], Item{
+			ID:     item.ID,
+			Title:  item.Title,
+			Number: item.Content.Number,
+			Status: status,
+			Labels: item.Content.Labels,
+		})
+	}
+
+	return summary, nil
+}
+
+// NextReady returns the highest-priority issue from the "Scoped" column.
+// Returns nil if no scoped issues are available.
+func NextReady(board *BoardSummary) *Item {
+	scoped := board.Columns["Scoped"]
+	if len(scoped) == 0 {
+		return nil
+	}
+	return &scoped[0]
+}
+
+// FormatBoard renders the board as a human-readable summary.
+func FormatBoard(board *BoardSummary) string {
+	var b strings.Builder
+
+	columnOrder := []string{"Someday/Maybe", "Backlog", "Scoped", "In Progress", "Review", "Done"}
+
+	_, _ = fmt.Fprintln(&b, "=== Project Board ===")
+	_, _ = fmt.Fprintln(&b)
+
+	for _, col := range columnOrder {
+		items := board.Columns[col]
+		_, _ = fmt.Fprintf(&b, "%s (%d)\n", col, len(items))
+
+		for _, item := range items {
+			labels := ""
+			if len(item.Labels) > 0 {
+				labels = " [" + strings.Join(item.Labels, ", ") + "]"
+			}
+			_, _ = fmt.Fprintf(&b, "  #%-4d %s%s\n", item.Number, item.Title, labels)
+		}
+
+		_, _ = fmt.Fprintln(&b)
+	}
+
+	// Any columns not in the standard order.
+	for col, items := range board.Columns {
+		if isStandardColumn(col, columnOrder) {
+			continue
+		}
+		_, _ = fmt.Fprintf(&b, "%s (%d)\n", col, len(items))
+		for _, item := range items {
+			_, _ = fmt.Fprintf(&b, "  #%-4d %s\n", item.Number, item.Title)
+		}
+		_, _ = fmt.Fprintln(&b)
+	}
+
+	return b.String()
+}
+
+func isStandardColumn(col string, standard []string) bool {
+	for _, s := range standard {
+		if col == s {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -1,0 +1,118 @@
+package project
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNextReadyReturnsFirstScoped(t *testing.T) {
+	t.Parallel()
+
+	board := &BoardSummary{
+		Columns: map[string][]Item{
+			"Scoped": {
+				{Number: 42, Title: "First scoped issue"},
+				{Number: 43, Title: "Second scoped issue"},
+			},
+			"In Progress": {
+				{Number: 10, Title: "Already in progress"},
+			},
+		},
+	}
+
+	next := NextReady(board)
+	if next == nil {
+		t.Fatal("expected a ready issue")
+	}
+
+	if next.Number != 42 {
+		t.Errorf("expected issue #42, got #%d", next.Number)
+	}
+}
+
+func TestNextReadyReturnsNilWhenNoScoped(t *testing.T) {
+	t.Parallel()
+
+	board := &BoardSummary{
+		Columns: map[string][]Item{
+			"In Progress": {
+				{Number: 10, Title: "Busy"},
+			},
+		},
+	}
+
+	next := NextReady(board)
+	if next != nil {
+		t.Errorf("expected nil, got issue #%d", next.Number)
+	}
+}
+
+func TestFormatBoardOutput(t *testing.T) {
+	t.Parallel()
+
+	board := &BoardSummary{
+		Columns: map[string][]Item{
+			"Scoped": {
+				{Number: 42, Title: "Add login", Labels: []string{"workflow:tdd"}},
+			},
+			"In Progress": {
+				{Number: 10, Title: "Fix bug"},
+			},
+			"Done": {
+				{Number: 1, Title: "Setup"},
+				{Number: 2, Title: "CI"},
+			},
+		},
+	}
+
+	out := FormatBoard(board)
+
+	checks := []string{
+		"=== Project Board ===",
+		"Scoped (1)",
+		"#42",
+		"Add login",
+		"[workflow:tdd]",
+		"In Progress (1)",
+		"#10",
+		"Done (2)",
+	}
+
+	for _, check := range checks {
+		if !strings.Contains(out, check) {
+			t.Errorf("expected output to contain %q\n\nGot:\n%s", check, out)
+		}
+	}
+}
+
+func TestFormatBoardShowsEmptyColumns(t *testing.T) {
+	t.Parallel()
+
+	board := &BoardSummary{
+		Columns: map[string][]Item{},
+	}
+
+	out := FormatBoard(board)
+
+	// All standard columns should appear with (0).
+	for _, col := range []string{"Someday/Maybe", "Backlog", "Scoped", "In Progress", "Review", "Done"} {
+		expected := col + " (0)"
+		if !strings.Contains(out, expected) {
+			t.Errorf("expected output to contain %q\n\nGot:\n%s", expected, out)
+		}
+	}
+}
+
+func TestIsStandardColumn(t *testing.T) {
+	t.Parallel()
+
+	standard := []string{"Scoped", "Done"}
+
+	if !isStandardColumn("Scoped", standard) {
+		t.Error("expected 'Scoped' to be standard")
+	}
+
+	if isStandardColumn("Custom", standard) {
+		t.Error("expected 'Custom' to not be standard")
+	}
+}


### PR DESCRIPTION
## Summary
- `rocket-fuel project link <url>` links a GitHub Project to the session
- `rocket-fuel project board` displays the board state by column
- `internal/project` package: FetchBoard, NextReady, FormatBoard
- Config stored in `.rocket-fuel/project.json`
- Standard columns: Someday/Maybe → Backlog → Scoped → In Progress → Review → Done

**Depends on:** #24 (`up`)

## Test plan
- [x] NextReady returns first Scoped issue
- [x] NextReady returns nil when no Scoped issues
- [x] FormatBoard shows all columns with counts
- [x] FormatBoard shows empty columns
- [x] isStandardColumn helper
- [x] `make lint` — 0 issues
- [x] `make test` passes

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)