### PR TITLE
feat: `rocket-fuel prime` — universal context injector

### DIFF
--- a/cmd/prime.go
+++ b/cmd/prime.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/drdanmaggs/rocket-fuel/internal/prime"
+	"github.com/drdanmaggs/rocket-fuel/internal/project"
+	"github.com/drdanmaggs/rocket-fuel/internal/session"
+	"github.com/drdanmaggs/rocket-fuel/internal/status"
+	"github.com/drdanmaggs/rocket-fuel/internal/tmux"
+	"github.com/spf13/cobra"
+)
+
+var primeCmd = &cobra.Command{
+	Use:   "prime",
+	Short: "Output Integrator context (board + workers + repo)",
+	Long: `Gathers board state, active workers, and repo context into a single
+markdown document. Used to prime the Integrator's Claude Code session.
+
+Output is suitable for piping to 'claude --prompt-file'.`,
+	RunE: runPrime,
+}
+
+func init() {
+	rootCmd.AddCommand(primeCmd)
+}
+
+func runPrime(cmd *cobra.Command, _ []string) error {
+	repoDir, err := statusRepoRoot()
+	if err != nil {
+		return fmt.Errorf("find repo root: %w", err)
+	}
+
+	in := &prime.Input{
+		RepoDir: repoDir,
+		Branch:  primeCurrentBranch(),
+	}
+
+	// Load integrator prompt.
+	promptPath := filepath.Join(repoDir, "prompts", "integrator.md")
+	if data, readErr := os.ReadFile(promptPath); readErr == nil {
+		in.IntegratorPrompt = string(data)
+	}
+
+	// Load board state (optional — project may not be linked).
+	if cfg, loadErr := loadProjectConfig(); loadErr == nil {
+		board, fetchErr := project.FetchBoard(cfg.Owner, cfg.ProjectNumber)
+		if fetchErr == nil {
+			in.Board = board
+		}
+	}
+
+	// Load worker status.
+	tm := tmux.New()
+	s, gatherErr := status.Gather(tm, session.DefaultSessionName, repoDir)
+	if gatherErr == nil {
+		in.Status = s
+	}
+
+	_, _ = fmt.Fprint(cmd.OutOrStdout(), prime.Build(in))
+	return nil
+}
+
+func primeCurrentBranch() string {
+	out, err := exec.CommandContext(context.Background(), "git", "branch", "--show-current").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/prime/prime.go
+++ b/internal/prime/prime.go
@@ -1,0 +1,58 @@
+// Package prime provides context injection for the Integrator agent.
+// Build assembles board state, worker status, and repo context into
+// a single markdown document — the Integrator's "eyes."
+package prime
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/drdanmaggs/rocket-fuel/internal/project"
+	"github.com/drdanmaggs/rocket-fuel/internal/status"
+)
+
+// Input holds the pre-fetched data needed to build the Integrator context.
+type Input struct {
+	IntegratorPrompt string
+	Board            *project.BoardSummary
+	Status           *status.Summary
+	RepoDir          string
+	Branch           string
+}
+
+// Build assembles the Integrator context document from pre-fetched data.
+func Build(in *Input) string {
+	var b strings.Builder
+
+	if in.IntegratorPrompt != "" {
+		_, _ = fmt.Fprintln(&b, in.IntegratorPrompt)
+	}
+
+	if in.Board != nil {
+		_, _ = fmt.Fprintln(&b)
+		_, _ = fmt.Fprintln(&b, "## Board")
+		_, _ = fmt.Fprintln(&b)
+		_, _ = fmt.Fprint(&b, project.FormatBoard(in.Board))
+	}
+
+	if in.Status != nil {
+		_, _ = fmt.Fprintln(&b)
+		_, _ = fmt.Fprintln(&b, "## Workers")
+		_, _ = fmt.Fprintln(&b)
+		_, _ = fmt.Fprint(&b, status.Format(in.Status))
+	}
+
+	if in.RepoDir != "" || in.Branch != "" {
+		_, _ = fmt.Fprintln(&b)
+		_, _ = fmt.Fprintln(&b, "## Repo")
+		_, _ = fmt.Fprintln(&b)
+		if in.RepoDir != "" {
+			_, _ = fmt.Fprintf(&b, "Directory: %s\n", in.RepoDir)
+		}
+		if in.Branch != "" {
+			_, _ = fmt.Fprintf(&b, "Branch: %s\n", in.Branch)
+		}
+	}
+
+	return b.String()
+}

--- a/internal/prime/prime_test.go
+++ b/internal/prime/prime_test.go
@@ -1,0 +1,181 @@
+package prime
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/drdanmaggs/rocket-fuel/internal/project"
+	"github.com/drdanmaggs/rocket-fuel/internal/status"
+)
+
+func TestBuild_includesIntegratorPrompt(t *testing.T) {
+	t.Parallel()
+
+	prompt := "You are the Integrator."
+	input := &Input{
+		IntegratorPrompt: prompt,
+	}
+
+	got := Build(input)
+
+	if !strings.Contains(got, prompt) {
+		t.Errorf("expected output to contain integrator prompt, got:\n%s", got)
+	}
+}
+
+func TestBuild_includesBoardState(t *testing.T) {
+	t.Parallel()
+
+	input := &Input{
+		Board: &project.BoardSummary{
+			Columns: map[string][]project.Item{
+				"Scoped": {
+					{Number: 42, Title: "Add login page", Labels: []string{"workflow:tdd"}},
+				},
+				"In Progress": {
+					{Number: 43, Title: "Fix auth bug"},
+				},
+			},
+		},
+	}
+
+	got := Build(input)
+
+	if !strings.Contains(got, "## Board") {
+		t.Error("expected Board section header")
+	}
+	if !strings.Contains(got, "#42") {
+		t.Error("expected issue #42 in output")
+	}
+	if !strings.Contains(got, "Add login page") {
+		t.Error("expected issue title in output")
+	}
+	if !strings.Contains(got, "Scoped") {
+		t.Error("expected column name in output")
+	}
+}
+
+func TestBuild_includesWorkerStatus(t *testing.T) {
+	t.Parallel()
+
+	input := &Input{
+		Status: &status.Summary{
+			SessionActive: true,
+			Workers: []status.WorkerStatus{
+				{Name: "worker-42", WindowOpen: true, Branch: "rf/issue-42", HasPR: false},
+				{Name: "worker-43", WindowOpen: false, Branch: "rf/issue-43", HasPR: true},
+			},
+		},
+	}
+
+	got := Build(input)
+
+	if !strings.Contains(got, "## Workers") {
+		t.Error("expected Workers section header")
+	}
+	if !strings.Contains(got, "worker-42") {
+		t.Error("expected worker-42 in output")
+	}
+	if !strings.Contains(got, "active") {
+		t.Error("expected active status for worker-42")
+	}
+	if !strings.Contains(got, "PR open") {
+		t.Error("expected PR indicator for worker-43")
+	}
+}
+
+func TestBuild_includesRepoContext(t *testing.T) {
+	t.Parallel()
+
+	input := &Input{
+		RepoDir: "/home/user/my-project",
+		Branch:  "main",
+	}
+
+	got := Build(input)
+
+	if !strings.Contains(got, "## Repo") {
+		t.Error("expected Repo section header")
+	}
+	if !strings.Contains(got, "/home/user/my-project") {
+		t.Error("expected repo dir in output")
+	}
+	if !strings.Contains(got, "main") {
+		t.Error("expected branch name in output")
+	}
+}
+
+func TestBuild_missingBoardOmitsSection(t *testing.T) {
+	t.Parallel()
+
+	input := &Input{
+		IntegratorPrompt: "You are the Integrator.",
+		// Board is nil — no project linked
+	}
+
+	got := Build(input)
+
+	if strings.Contains(got, "## Board") {
+		t.Error("expected no Board section when board is nil")
+	}
+	if !strings.Contains(got, "You are the Integrator.") {
+		t.Error("expected integrator prompt even without board")
+	}
+}
+
+func TestBuild_missingWorkersShowsNone(t *testing.T) {
+	t.Parallel()
+
+	input := &Input{
+		Status: &status.Summary{
+			SessionActive: true,
+			Workers:       nil,
+		},
+	}
+
+	got := Build(input)
+
+	if !strings.Contains(got, "## Workers") {
+		t.Error("expected Workers section even with no workers")
+	}
+	if !strings.Contains(got, "none") {
+		t.Error("expected 'none' when no workers exist")
+	}
+}
+
+func TestBuild_fullAssemblyOrdersCorrectly(t *testing.T) {
+	t.Parallel()
+
+	input := &Input{
+		IntegratorPrompt: "PROMPT_SECTION",
+		Board: &project.BoardSummary{
+			Columns: map[string][]project.Item{
+				"Scoped": {{Number: 1, Title: "Issue one"}},
+			},
+		},
+		Status: &status.Summary{
+			SessionActive: true,
+			Workers: []status.WorkerStatus{
+				{Name: "worker-1", WindowOpen: true, Branch: "rf/issue-1"},
+			},
+		},
+		RepoDir: "/repo",
+		Branch:  "main",
+	}
+
+	got := Build(input)
+
+	// Verify section ordering: prompt → board → workers → repo.
+	promptIdx := strings.Index(got, "PROMPT_SECTION")
+	boardIdx := strings.Index(got, "## Board")
+	workersIdx := strings.Index(got, "## Workers")
+	repoIdx := strings.Index(got, "## Repo")
+
+	if promptIdx < 0 || boardIdx < 0 || workersIdx < 0 || repoIdx < 0 {
+		t.Fatalf("missing section(s) in output:\n%s", got)
+	}
+	if !(promptIdx < boardIdx && boardIdx < workersIdx && workersIdx < repoIdx) {
+		t.Errorf("sections out of order: prompt=%d board=%d workers=%d repo=%d",
+			promptIdx, boardIdx, workersIdx, repoIdx)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `rocket-fuel prime` command — the Integrator's "eyes"
- `Build()` assembles board state, worker status, repo context into structured markdown
- Graceful degradation when data is missing (no project linked, no workers)
- Output suitable for `claude --prompt-file`

Closes #36

## Test plan
- [x] Unit tests for Build() with all combinations of input data
- [x] Section ordering verified (prompt → board → workers → repo)
- [x] Nil/empty inputs produce graceful output
- [x] Full test suite passes (`go test -race ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)