### PR TITLE
fix: add HasWindow to tmux.Runner — no more tab switching on status checks

### DIFF
--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -11,6 +11,7 @@ type mockRunner struct {
 }
 
 func (m *mockRunner) HasSession(_ string) bool      { return true }
+func (m *mockRunner) HasWindow(_, _ string) bool    { return true }
 func (m *mockRunner) NewSession(_ string) error     { return nil }
 func (m *mockRunner) NewWindow(_, _ string) error   { return nil }
 func (m *mockRunner) KillSession(_ string) error    { return nil }

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -24,6 +24,16 @@ func (m *mockRunner) HasSession(name string) bool {
 	return m.sessions[name]
 }
 
+func (m *mockRunner) HasWindow(session, window string) bool {
+	m.calls = append(m.calls, "HasWindow:"+session+":"+window)
+	for _, w := range m.windows[session] {
+		if w == window {
+			return true
+		}
+	}
+	return false
+}
+
 func (m *mockRunner) NewSession(name string) error {
 	m.calls = append(m.calls, "NewSession:"+name)
 	if m.failOn == "NewSession" {

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -54,7 +54,7 @@ func Gather(tm tmux.Runner, sessionName, repoDir string) (*Summary, error) {
 
 		ws := WorkerStatus{
 			Name:       name,
-			WindowOpen: s.SessionActive && tm.SelectWindow(sessionName, name) == nil,
+			WindowOpen: s.SessionActive && tm.HasWindow(sessionName, name),
 			Branch:     worktreeBranch(worktreeDir),
 		}
 

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -19,7 +19,12 @@ func newMockRunner() *mockRunner {
 	}
 }
 
-func (m *mockRunner) HasSession(name string) bool   { return m.sessions[name] }
+func (m *mockRunner) HasSession(name string) bool { return m.sessions[name] }
+
+func (m *mockRunner) HasWindow(session, window string) bool {
+	return m.windows[session] != nil && m.windows[session][window]
+}
+
 func (m *mockRunner) NewSession(_ string) error     { return nil }
 func (m *mockRunner) NewWindow(_, _ string) error   { return nil }
 func (m *mockRunner) KillSession(_ string) error    { return nil }

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -14,6 +14,7 @@ import (
 // Real implementation calls tmux CLI; test doubles record commands.
 type Runner interface {
 	HasSession(name string) bool
+	HasWindow(session, window string) bool
 	NewSession(name string) error
 	NewWindow(session, name string) error
 	SelectWindow(session, window string) error
@@ -41,6 +42,21 @@ func NewWithSocket(socket string) *CLI {
 // HasSession checks if a tmux session with the given name exists.
 func (c *CLI) HasSession(name string) bool {
 	return c.run("has-session", "-t", name) == nil
+}
+
+// HasWindow checks if a window with the given name exists in the session.
+// Unlike SelectWindow, this does NOT change the active window — it's read-only.
+func (c *CLI) HasWindow(session, window string) bool {
+	out, err := c.output("list-windows", "-t", session, "-F", "#{window_name}")
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if line == window {
+			return true
+		}
+	}
+	return false
 }
 
 // NewSession creates a new detached tmux session.
@@ -87,6 +103,20 @@ func (c *CLI) AttachCC(session string) error {
 // SendKeys sends keystrokes to a specific window in a session.
 func (c *CLI) SendKeys(session, window, keys string) error {
 	return c.run("send-keys", "-t", session+":"+window, keys, "Enter")
+}
+
+func (c *CLI) output(args ...string) (string, error) {
+	fullArgs := args
+	if c.socket != "" {
+		fullArgs = append([]string{"-L", c.socket}, args...)
+	}
+
+	cmd := exec.CommandContext(context.Background(), "tmux", fullArgs...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("tmux %s: %w\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
 }
 
 func (c *CLI) run(args ...string) error {

--- a/internal/worker/reap.go
+++ b/internal/worker/reap.go
@@ -81,8 +81,7 @@ func Reap(tm tmux.Runner, sessionName, repoDir string) ([]ReapResult, error) {
 }
 
 func hasWindow(tm tmux.Runner, session, window string) bool {
-	// SelectWindow returns nil if the window exists.
-	return tm.SelectWindow(session, window) == nil
+	return tm.HasWindow(session, window)
 }
 
 func removeWorktree(repoDir, worktreeDir string) error {

--- a/internal/worker/reap_test.go
+++ b/internal/worker/reap_test.go
@@ -23,6 +23,10 @@ func (m *mockTmuxRunner) HasSession(name string) bool {
 	return m.sessions[name]
 }
 
+func (m *mockTmuxRunner) HasWindow(session, window string) bool {
+	return m.windows[session] != nil && m.windows[session][window]
+}
+
 func (m *mockTmuxRunner) NewSession(name string) error {
 	m.sessions[name] = true
 	if m.windows[name] == nil {


### PR DESCRIPTION
## Summary
- Adds `HasWindow(session, window) bool` to `tmux.Runner` using `tmux list-windows` (read-only)
- Replaces `SelectWindow`-as-existence-check in `reap.go` and `status.go`
- No more silent tab switching on `rf status`, `rf dispatch`, or heartbeat cycles

Closes #52

## Test plan
- [x] All existing tests pass with new interface method
- [x] Mock runners updated across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)