### PR TITLE
feat: Auto-discover and auto-create GitHub Project on rf launch

### DIFF
--- a/cmd/project.go
+++ b/cmd/project.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -125,14 +127,66 @@ func loadProjectConfig() (*project.Config, error) {
 	}
 
 	data, err := os.ReadFile(filepath.Join(dir, "project.json"))
+	if err == nil {
+		var cfg project.Config
+		if parseErr := json.Unmarshal(data, &cfg); parseErr == nil {
+			return &cfg, nil
+		}
+	}
+
+	// No config file — try auto-discovery from GitHub.
+	cfg, discoverErr := discoverAndSaveProject()
+	if discoverErr != nil {
+		return nil, fmt.Errorf("no project linked and auto-discovery failed: %w", discoverErr)
+	}
+	return cfg, nil
+}
+
+func discoverAndSaveProject() (*project.Config, error) {
+	owner, repo, err := repoOwnerAndName()
 	if err != nil {
 		return nil, err
 	}
 
-	var cfg project.Config
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		return nil, err
+	// Try discover first.
+	cfg, err := project.Discover(ghRunner, owner, repo)
+	if err != nil {
+		// No existing project — create one.
+		fmt.Fprintf(os.Stderr, "No GitHub Project found for %s/%s — creating one...\n", owner, repo)
+		cfg, err = project.Create(ghRunner, owner, repo)
+		if err != nil {
+			return nil, fmt.Errorf("auto-create project failed: %w", err)
+		}
+		fmt.Fprintf(os.Stderr, "Created project #%d for %s/%s\n", cfg.ProjectNumber, owner, repo)
+	} else {
+		fmt.Fprintf(os.Stderr, "Auto-discovered project #%d for %s/%s\n", cfg.ProjectNumber, owner, repo)
 	}
 
-	return &cfg, nil
+	// Save for next time.
+	if saveErr := saveProjectConfig(*cfg); saveErr != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not save project config: %v\n", saveErr)
+	}
+
+	return cfg, nil
+}
+
+func repoOwnerAndName() (string, string, error) {
+	out, err := exec.CommandContext(context.Background(),
+		"gh", "repo", "view", "--json", "owner,name",
+	).Output()
+	if err != nil {
+		return "", "", fmt.Errorf("detect repo: %w", err)
+	}
+
+	var repo struct {
+		Owner struct {
+			Login string `json:"login"`
+		} `json:"owner"`
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(out, &repo); err != nil {
+		return "", "", fmt.Errorf("parse repo info: %w", err)
+	}
+
+	return repo.Owner.Login, repo.Name, nil
 }

--- a/internal/project/discover.go
+++ b/internal/project/discover.go
@@ -1,0 +1,70 @@
+package project
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Create makes a new GitHub Project board for the repository.
+func Create(run GHRunner, owner, repo string) (*Config, error) {
+	out, err := run("project", "create", "--owner", owner, "--title", repo, "--format", "json")
+	if err != nil {
+		return nil, fmt.Errorf("create project: %w", err)
+	}
+
+	var resp struct {
+		Number int    `json:"number"`
+		URL    string `json:"url"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return nil, fmt.Errorf("parse create response: %w", err)
+	}
+
+	return &Config{
+		Owner:         owner,
+		ProjectNumber: resp.Number,
+	}, nil
+}
+
+// Discover finds a GitHub Project linked to a repository via the GitHub API.
+// Returns the first project found, or an error if none exist.
+func Discover(run GHRunner, owner, repo string) (*Config, error) {
+	query := fmt.Sprintf(
+		`query { repository(owner: "%s", name: "%s") { projectsV2(first: 5) { nodes { id title number url } } } }`,
+		owner, repo,
+	)
+
+	out, err := run("api", "graphql", "-f", "query="+query)
+	if err != nil {
+		return nil, fmt.Errorf("query projects: %w", err)
+	}
+
+	var resp struct {
+		Data struct {
+			Repository struct {
+				ProjectsV2 struct {
+					Nodes []struct {
+						ID     string `json:"id"`
+						Title  string `json:"title"`
+						Number int    `json:"number"`
+						URL    string `json:"url"`
+					} `json:"nodes"`
+				} `json:"projectsV2"`
+			} `json:"repository"`
+		} `json:"data"`
+	}
+
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return nil, fmt.Errorf("parse projects response: %w", err)
+	}
+
+	nodes := resp.Data.Repository.ProjectsV2.Nodes
+	if len(nodes) == 0 {
+		return nil, fmt.Errorf("no GitHub Project found for %s/%s", owner, repo)
+	}
+
+	return &Config{
+		Owner:         owner,
+		ProjectNumber: nodes[0].Number,
+	}, nil
+}

--- a/internal/project/discover_test.go
+++ b/internal/project/discover_test.go
@@ -1,0 +1,83 @@
+package project
+
+import (
+	"testing"
+)
+
+func TestDiscover_parsesProjectFromResponse(t *testing.T) {
+	t.Parallel()
+
+	response := []byte(`{"data":{"repository":{"projectsV2":{"nodes":[{"id":"PVT_abc","title":"My Project","number":16,"url":"https://github.com/users/owner/projects/16"}]}}}}`)
+
+	runner := func(_ ...string) ([]byte, error) {
+		return response, nil
+	}
+
+	cfg, err := Discover(runner, "owner", "my-repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Owner != "owner" {
+		t.Errorf("expected owner 'owner', got %q", cfg.Owner)
+	}
+	if cfg.ProjectNumber != 16 {
+		t.Errorf("expected project 16, got %d", cfg.ProjectNumber)
+	}
+}
+
+func TestDiscover_returnsErrorWhenNoProjects(t *testing.T) {
+	t.Parallel()
+
+	response := []byte(`{"data":{"repository":{"projectsV2":{"nodes":[]}}}}`)
+
+	runner := func(_ ...string) ([]byte, error) {
+		return response, nil
+	}
+
+	_, err := Discover(runner, "owner", "my-repo")
+	if err == nil {
+		t.Fatal("expected error when no projects found")
+	}
+}
+
+func TestCreate_returnsNewProject(t *testing.T) {
+	t.Parallel()
+
+	response := []byte(`{"number":42,"url":"https://github.com/users/owner/projects/42","title":"my-repo"}`)
+
+	runner := func(_ ...string) ([]byte, error) {
+		return response, nil
+	}
+
+	cfg, err := Create(runner, "owner", "my-repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Owner != "owner" {
+		t.Errorf("expected owner 'owner', got %q", cfg.Owner)
+	}
+	if cfg.ProjectNumber != 42 {
+		t.Errorf("expected project 42, got %d", cfg.ProjectNumber)
+	}
+}
+
+func TestDiscover_returnsFirstProjectWhenMultiple(t *testing.T) {
+	t.Parallel()
+
+	response := []byte(`{"data":{"repository":{"projectsV2":{"nodes":[{"id":"PVT_1","title":"First","number":5,"url":"https://github.com/users/owner/projects/5"},{"id":"PVT_2","title":"Second","number":10,"url":"https://github.com/users/owner/projects/10"}]}}}}`)
+
+	runner := func(_ ...string) ([]byte, error) {
+		return response, nil
+	}
+
+	cfg, err := Discover(runner, "owner", "my-repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.ProjectNumber != 5 {
+		t.Errorf("expected first project (5), got %d", cfg.ProjectNumber)
+	}
+}


### PR DESCRIPTION
## Summary

- `rf launch` now just works — no `rf project link` step needed
- Auto-discovers GitHub Projects linked to the repo via GraphQL API
- Auto-creates a new project if none exists
- Saves config for instant startup on subsequent launches

The flow: file cache → discover → create. User types `rf launch`, everything else is automatic.

## Test plan
- [x] Discover parses GraphQL response correctly
- [x] Discover returns error when no projects found
- [x] Discover returns first project when multiple exist
- [x] Create parses gh project create response
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)