### PR TITLE
fix: use --system-prompt instead of non-existent --prompt-file

### DIFF
--- a/internal/launch/launch.go
+++ b/internal/launch/launch.go
@@ -16,7 +16,7 @@ type WindowCommand struct {
 	Command string
 }
 
-// WritePrimeContext writes the prime context to a file for claude --prompt-file.
+// WritePrimeContext writes the prime context to a file for claude --system-prompt.
 // Returns the file path.
 func WritePrimeContext(repoDir string, input *prime.Input) (string, error) {
 	dir := filepath.Join(repoDir, ".rocket-fuel")
@@ -35,8 +35,9 @@ func WritePrimeContext(repoDir string, input *prime.Input) (string, error) {
 }
 
 // IntegratorCommand returns the claude launch command for the integrator window.
+// Uses --system-prompt with $(cat <file>) to load the context from disk.
 func IntegratorCommand(contextFilePath string) string {
-	return fmt.Sprintf("claude --prompt-file %s", shellQuote(contextFilePath))
+	return fmt.Sprintf("claude --system-prompt \"$(cat %s)\"", shellQuote(contextFilePath))
 }
 
 // shellQuote wraps a string in single quotes, escaping any embedded single quotes.

--- a/internal/launch/launch_test.go
+++ b/internal/launch/launch_test.go
@@ -43,13 +43,19 @@ func TestWritePrimeContext_createsFile(t *testing.T) {
 	}
 }
 
-func TestIntegratorCommand_includesPromptFile(t *testing.T) {
+func TestIntegratorCommand_usesSystemPrompt(t *testing.T) {
 	t.Parallel()
 
 	cmd := IntegratorCommand("/tmp/context.md")
 
-	if cmd != "claude --prompt-file '/tmp/context.md'" {
-		t.Errorf("unexpected command: %q", cmd)
+	if !strings.Contains(cmd, "--system-prompt") {
+		t.Errorf("expected --system-prompt flag, got: %q", cmd)
+	}
+	if !strings.Contains(cmd, "$(cat") {
+		t.Errorf("expected $(cat ...) to read file, got: %q", cmd)
+	}
+	if !strings.Contains(cmd, "/tmp/context.md") {
+		t.Errorf("expected file path in command, got: %q", cmd)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `--prompt-file` doesn't exist in Claude CLI
- Changed to `claude --system-prompt "$(cat <file>)"` which reads the context file via shell expansion
- Tests updated

Closes #71

## Test plan
- [x] Tests verify --system-prompt flag and $(cat) pattern
- [x] Path quoting still works for spaces
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)