### PR TITLE
feat: Simplify rf launch to integrator-only visible tab

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -40,7 +40,7 @@ func runUp(cmd *cobra.Command, _ []string) error {
 	}
 
 	if created {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Created session %q with windows: integrator, heartbeat, dashboard\n", sessionName)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Created session %q\n", sessionName)
 
 		// Launch Claude Code in the integrator window with prime context.
 		if launchErr := launchIntegrator(tm, sessionName); launchErr != nil {
@@ -49,18 +49,9 @@ func runUp(cmd *cobra.Command, _ []string) error {
 			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Launched Claude Code in integrator tab.")
 		}
 
-		// Launch heartbeat loop in the heartbeat window.
-		if err := tm.SendKeys(sessionName, "heartbeat", "rf heartbeat --loop"); err != nil {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Warning: could not launch heartbeat: %v\n", err)
-		} else {
-			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Launched heartbeat in background tab.")
-		}
-
-		// Launch status in the dashboard window.
-		if err := tm.SendKeys(sessionName, "dashboard", "rf status"); err != nil {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Warning: could not launch dashboard: %v\n", err)
-		} else {
-			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Launched status in dashboard tab.")
+		// Launch mission control (heartbeat loop) in background window.
+		if err := tm.SendKeys(sessionName, session.WindowMissionCtrl, "rf heartbeat --loop"); err != nil {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Warning: could not launch mission control: %v\n", err)
 		}
 	} else {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Attaching to existing session %q\n", sessionName)

--- a/internal/launch/launch.go
+++ b/internal/launch/launch.go
@@ -16,7 +16,7 @@ type WindowCommand struct {
 	Command string
 }
 
-// WritePrimeContext writes the prime context to a file for claude --prompt-file.
+// WritePrimeContext writes the prime context to a file for claude --system-prompt.
 // Returns the file path.
 func WritePrimeContext(repoDir string, input *prime.Input) (string, error) {
 	dir := filepath.Join(repoDir, ".rocket-fuel")
@@ -35,8 +35,9 @@ func WritePrimeContext(repoDir string, input *prime.Input) (string, error) {
 }
 
 // IntegratorCommand returns the claude launch command for the integrator window.
+// Uses --system-prompt with $(cat <file>) to load the context from disk.
 func IntegratorCommand(contextFilePath string) string {
-	return fmt.Sprintf("claude --prompt-file %s", shellQuote(contextFilePath))
+	return fmt.Sprintf("claude --system-prompt \"$(cat %s)\"", shellQuote(contextFilePath))
 }
 
 // shellQuote wraps a string in single quotes, escaping any embedded single quotes.

--- a/internal/launch/launch_test.go
+++ b/internal/launch/launch_test.go
@@ -43,13 +43,19 @@ func TestWritePrimeContext_createsFile(t *testing.T) {
 	}
 }
 
-func TestIntegratorCommand_includesPromptFile(t *testing.T) {
+func TestIntegratorCommand_usesSystemPrompt(t *testing.T) {
 	t.Parallel()
 
 	cmd := IntegratorCommand("/tmp/context.md")
 
-	if cmd != "claude --prompt-file '/tmp/context.md'" {
-		t.Errorf("unexpected command: %q", cmd)
+	if !strings.Contains(cmd, "--system-prompt") {
+		t.Errorf("expected --system-prompt flag, got: %q", cmd)
+	}
+	if !strings.Contains(cmd, "$(cat") {
+		t.Errorf("expected $(cat ...) to read file, got: %q", cmd)
+	}
+	if !strings.Contains(cmd, "/tmp/context.md") {
+		t.Errorf("expected file path in command, got: %q", cmd)
 	}
 }
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -10,10 +10,15 @@ import (
 // DefaultSessionName is the tmux session name used by Rocket Fuel.
 const DefaultSessionName = "rocket-fuel"
 
-// Windows defines the tmux windows created for a Rocket Fuel session.
-var Windows = []string{"integrator", "heartbeat", "dashboard"}
+// Window names for the Rocket Fuel session.
+const (
+	WindowIntegrator  = "integrator"
+	WindowMissionCtrl = "mission-control"
+)
 
-// Setup creates the Rocket Fuel tmux session with all agent windows.
+// Setup creates the Rocket Fuel tmux session.
+// Window 0 is renamed to "integrator" (no orphan window).
+// A background "mission-control" window is created for the heartbeat loop.
 // Returns true if a new session was created, false if one already existed.
 func Setup(tm tmux.Runner, sessionName string) (bool, error) {
 	if tm.HasSession(sessionName) {
@@ -24,16 +29,19 @@ func Setup(tm tmux.Runner, sessionName string) (bool, error) {
 		return false, fmt.Errorf("create session: %w", err)
 	}
 
-	for _, win := range Windows {
-		if err := tm.NewWindow(sessionName, win); err != nil {
-			// Clean up on partial failure.
-			_ = tm.KillSession(sessionName)
-			return false, fmt.Errorf("create window %q: %w", win, err)
-		}
+	// Rename the default window (window 0) to "integrator".
+	if cli, ok := tm.(*tmux.CLI); ok {
+		_ = cli.RenameWindow(sessionName, "0", WindowIntegrator)
 	}
 
-	// Switch back to the first window (integrator).
-	if err := tm.SelectWindow(sessionName, Windows[0]); err != nil {
+	// Create the mission-control window for the heartbeat loop.
+	if err := tm.NewWindow(sessionName, WindowMissionCtrl); err != nil {
+		_ = tm.KillSession(sessionName)
+		return false, fmt.Errorf("create window %q: %w", WindowMissionCtrl, err)
+	}
+
+	// Select the integrator window so user lands there.
+	if err := tm.SelectWindow(sessionName, WindowIntegrator); err != nil {
 		return true, fmt.Errorf("select window: %w", err)
 	}
 

--- a/internal/session/session_integration_test.go
+++ b/internal/session/session_integration_test.go
@@ -45,14 +45,17 @@ func TestSetupCreatesAllWindows_Integration(t *testing.T) {
 		t.Fatal("expected session to exist after Setup")
 	}
 
-	// List windows and verify all 3 are present.
+	// List windows and verify integrator + mission-control are present.
 	windows := listWindows(t, sessionName)
 
-	expected := []string{"integrator", "heartbeat", "dashboard"}
+	expected := []string{"integrator", "mission-control"}
 	for _, name := range expected {
 		if !contains(windows, name) {
 			t.Errorf("expected window %q to exist, got windows: %v", name, windows)
 		}
+	}
+	if len(windows) != 2 {
+		t.Errorf("expected exactly 2 windows, got %d: %v", len(windows), windows)
 	}
 }
 

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -82,7 +82,7 @@ type mockError struct{}
 
 func (e *mockError) Error() string { return "mock error" }
 
-func TestSetupCreatesSessionAndWindows(t *testing.T) {
+func TestSetupCreatesSessionAndMissionControlWindow(t *testing.T) {
 	t.Parallel()
 
 	tm := newMockRunner()
@@ -100,15 +100,14 @@ func TestSetupCreatesSessionAndWindows(t *testing.T) {
 		t.Error("expected session to exist")
 	}
 
+	// Setup creates one additional window: mission-control.
+	// Window 0 (integrator) is the default from NewSession (renamed via CLI only).
 	windows := tm.windows["test-session"]
-	if len(windows) != len(Windows) {
-		t.Errorf("expected %d windows, got %d", len(Windows), len(windows))
+	if len(windows) != 1 {
+		t.Errorf("expected 1 window created (mission-control), got %d: %v", len(windows), windows)
 	}
-
-	for i, expected := range Windows {
-		if windows[i] != expected {
-			t.Errorf("window %d: expected %q, got %q", i, expected, windows[i])
-		}
+	if len(windows) > 0 && windows[0] != WindowMissionCtrl {
+		t.Errorf("expected window %q, got %q", WindowMissionCtrl, windows[0])
 	}
 }
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -100,6 +100,16 @@ func (c *CLI) AttachCC(session string) error {
 	return syscall.Exec(tmuxPath, args, os.Environ())
 }
 
+// RenameWindow changes the name of a window in a session.
+// Target can be a window name or index (e.g., "0" for the first window).
+func (c *CLI) RenameWindow(session, target, newName string) error {
+	windowTarget := session + ":" + target
+	if target == "" {
+		windowTarget = session
+	}
+	return c.run("rename-window", "-t", windowTarget, newName)
+}
+
 // SendKeys sends keystrokes to a specific window in a session.
 func (c *CLI) SendKeys(session, window, keys string) error {
 	return c.run("send-keys", "-t", session+":"+window, keys, "Enter")


### PR DESCRIPTION
## Summary
- Eliminates orphan bash tab (window 0 → renamed to integrator)
- Removes dashboard window (use rf status on demand)
- Heartbeat runs in hidden "mission-control" window
- User sees 2 tabs instead of 4, lands on integrator

Closes #72

## Test plan
- [x] Unit tests updated for new window structure
- [x] Integration tests updated (2 windows: integrator + mission-control)
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)