### PR TITLE
feat: rf launch auto-updates binary when stale

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
-LDFLAGS := -ldflags "-X github.com/drdanmaggs/rocket-fuel/cmd.Version=$(VERSION)"
+SOURCE_DIR := $(shell pwd)
+LDFLAGS := -ldflags "-X github.com/drdanmaggs/rocket-fuel/cmd.Version=$(VERSION) -X github.com/drdanmaggs/rocket-fuel/cmd.SourceDir=$(SOURCE_DIR)"
 
 .PHONY: build install test test-unit test-integration lint fmt fmt-check clean all setup
 

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -5,10 +5,12 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"syscall"
 
 	"github.com/drdanmaggs/rocket-fuel/internal/launch"
 	"github.com/drdanmaggs/rocket-fuel/internal/prime"
 	"github.com/drdanmaggs/rocket-fuel/internal/project"
+	"github.com/drdanmaggs/rocket-fuel/internal/selfupdate"
 	"github.com/drdanmaggs/rocket-fuel/internal/session"
 	"github.com/drdanmaggs/rocket-fuel/internal/status"
 	"github.com/drdanmaggs/rocket-fuel/internal/tmux"
@@ -33,6 +35,10 @@ func init() {
 
 func runUp(cmd *cobra.Command, _ []string) error {
 	out := cmd.OutOrStdout()
+
+	// Self-update: check if binary is stale, rebuild if needed.
+	selfUpdate(out)
+
 	tm := tmux.New()
 	sessionName := session.DefaultSessionName
 
@@ -137,4 +143,23 @@ func launchIntegrator(tm tmux.Runner, sessionName string) error {
 
 	launchCmd := launch.IntegratorCommand(contextPath)
 	return tm.SendKeys(sessionName, "integrator", launchCmd)
+}
+
+func selfUpdate(w io.Writer) {
+	binaryPath, err := os.Executable()
+	if err != nil {
+		return
+	}
+
+	result, err := selfupdate.Check(SourceDir, Version, binaryPath)
+	if err != nil || result == nil {
+		return
+	}
+
+	if result.Updated {
+		_, _ = fmt.Fprintf(w, "  Updated rf: %s -> %s\n", result.OldVersion, result.NewVersion)
+		// Re-exec the new binary with the same args.
+		_ = syscall.Exec(binaryPath, os.Args, os.Environ())
+		// If exec fails, continue with current binary.
+	}
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,6 +9,9 @@ import (
 // Version is set at build time via ldflags.
 var Version = "dev"
 
+// SourceDir is set at build time via ldflags — path to the rocket-fuel source repo.
+var SourceDir = ""
+
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version of Rocket Fuel",

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -1,0 +1,99 @@
+// Package selfupdate handles automatic binary updates from the source repo.
+package selfupdate
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// Result describes what happened during an update check.
+type Result struct {
+	Updated    bool
+	OldVersion string
+	NewVersion string
+	Skipped    string // reason if skipped
+}
+
+// Check compares the running binary's version against the source repo HEAD.
+// If stale, pulls latest and rebuilds the binary in-place.
+// Returns the result and any error (errors are non-fatal — caller should continue).
+func Check(sourceDir, currentVersion, binaryPath string) (*Result, error) {
+	if sourceDir == "" {
+		return &Result{Skipped: "no source directory configured"}, nil
+	}
+
+	if _, err := os.Stat(sourceDir); err != nil {
+		return &Result{Skipped: "source directory not found"}, nil
+	}
+
+	// Get the latest commit on origin/main.
+	headCommit, err := gitOutput(sourceDir, "rev-parse", "--short", "origin/main")
+	if err != nil {
+		// Try fetching first — origin/main might not be up to date.
+		_ = gitRun(sourceDir, "fetch", "origin", "main", "--quiet")
+		headCommit, err = gitOutput(sourceDir, "rev-parse", "--short", "origin/main")
+		if err != nil {
+			return &Result{Skipped: "could not read origin/main"}, nil
+		}
+	}
+
+	// Compare versions.
+	if currentVersion == headCommit || strings.HasPrefix(headCommit, currentVersion) || strings.HasPrefix(currentVersion, headCommit) {
+		return &Result{Skipped: "already up to date"}, nil
+	}
+
+	// Pull latest.
+	if err := gitRun(sourceDir, "pull", "origin", "main", "--ff-only", "--quiet"); err != nil {
+		return &Result{Skipped: fmt.Sprintf("pull failed: %v", err)}, nil
+	}
+
+	// Rebuild.
+	if err := goBuild(sourceDir, binaryPath); err != nil {
+		return &Result{Skipped: fmt.Sprintf("build failed: %v", err)}, nil
+	}
+
+	return &Result{
+		Updated:    true,
+		OldVersion: currentVersion,
+		NewVersion: headCommit,
+	}, nil
+}
+
+func gitOutput(dir string, args ...string) (string, error) {
+	cmd := exec.CommandContext(context.Background(), "git", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func gitRun(dir string, args ...string) error {
+	cmd := exec.CommandContext(context.Background(), "git", args...)
+	cmd.Dir = dir
+	return cmd.Run()
+}
+
+func goBuild(sourceDir, binaryPath string) error {
+	cmd := exec.CommandContext(context.Background(),
+		"go", "build",
+		"-ldflags", fmt.Sprintf("-s -w -X github.com/drdanmaggs/rocket-fuel/cmd.Version=%s -X github.com/drdanmaggs/rocket-fuel/cmd.SourceDir=%s", shortHead(sourceDir), sourceDir),
+		"-o", binaryPath,
+		".",
+	)
+	cmd.Dir = sourceDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, out)
+	}
+	return nil
+}
+
+func shortHead(dir string) string {
+	s, _ := gitOutput(dir, "rev-parse", "--short", "HEAD")
+	return s
+}

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -1,0 +1,35 @@
+package selfupdate
+
+import (
+	"testing"
+)
+
+func TestCheck_skipsWhenNoSourceDir(t *testing.T) {
+	t.Parallel()
+
+	result, err := Check("", "abc123", "/tmp/rf")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Updated {
+		t.Error("expected skip, not update")
+	}
+	if result.Skipped != "no source directory configured" {
+		t.Errorf("unexpected skip reason: %q", result.Skipped)
+	}
+}
+
+func TestCheck_skipsWhenSourceDirMissing(t *testing.T) {
+	t.Parallel()
+
+	result, err := Check("/nonexistent/path", "abc123", "/tmp/rf")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Updated {
+		t.Error("expected skip, not update")
+	}
+	if result.Skipped != "source directory not found" {
+		t.Errorf("unexpected skip reason: %q", result.Skipped)
+	}
+}


### PR DESCRIPTION
## Summary
- `rf launch` checks if the binary is stale against origin/main
- If stale: fetches, pulls, rebuilds, re-execs — fully automatic
- If anything fails: continues with current binary (never blocks)
- `SourceDir` embedded at build time via ldflags
- Makefile `install` target sets SourceDir automatically

No more manual `go build` after merging PRs. `rf launch` just works.

Closes #79

## Test plan
- [x] Check skips when no source dir configured
- [x] Check skips when source dir missing
- [x] Full test suite passes
- [x] `make install` embeds SourceDir correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)