### PR TITLE
fix: rf launch errors when not in a git repo

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -36,6 +36,11 @@ func init() {
 func runUp(cmd *cobra.Command, _ []string) error {
 	out := cmd.OutOrStdout()
 
+	// Pre-flight: must be in a git repo.
+	if _, err := repoRoot(); err != nil {
+		return fmt.Errorf("not in a git repository — cd into your project first")
+	}
+
 	// Self-update: check if binary is stale, rebuild if needed.
 	selfUpdate(out)
 


### PR DESCRIPTION
## Summary
- Pre-flight check: `rf launch` fails fast if not in a git repo
- Clear error message: "not in a git repository — cd into your project first"

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)