### PR TITLE
fix: Create mission-control tab after tmux -CC attachment

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"syscall"
 
@@ -20,10 +22,10 @@ import (
 var upCmd = &cobra.Command{
 	Use:   "launch",
 	Short: "Start the Rocket Fuel tmux session",
-	Long: `Creates a tmux session with Integrator and Dashboard windows,
-launches Claude Code in the Integrator tab with full project context,
-then attaches in control mode (-CC) so iTerm2 renders them as native tabs.
+	Long: `Creates a tmux session, launches Claude Code in the Integrator tab,
+then attaches in control mode (-CC) so iTerm2 renders native tabs.
 
+Mission control starts as a background tab after attachment.
 If a session already exists, attaches to it without relaunching.`,
 	RunE: runUp,
 }
@@ -61,10 +63,10 @@ func runUp(cmd *cobra.Command, _ []string) error {
 			_, _ = fmt.Fprintf(out, "  Warning: could not launch integrator: %v\n", launchErr)
 		}
 
-		// Launch mission control in background window.
-		if err := tm.SendKeys(sessionName, session.WindowMissionCtrl, "rf mission-control --loop"); err != nil {
-			_, _ = fmt.Fprintf(out, "  Warning: could not launch mission control: %v\n", err)
-		}
+		// Start a background process that creates mission-control AFTER
+		// tmux -CC attaches. This ensures iTerm2 sees the window creation
+		// as a live event and renders it as a tab, not a separate window.
+		spawnPostAttachSetup(sessionName)
 
 		_, _ = fmt.Fprintln(out)
 	} else {
@@ -83,6 +85,24 @@ func runUp(cmd *cobra.Command, _ []string) error {
 	}
 
 	return nil
+}
+
+// spawnPostAttachSetup starts a detached background process that waits for -CC
+// attachment, then creates the mission-control window and launches heartbeat.
+// This must be a separate process because syscall.Exec replaces the current one.
+func spawnPostAttachSetup(sessionName string) {
+	// Shell script that waits for -CC to attach, then creates the window.
+	script := fmt.Sprintf(
+		`sleep 2 && tmux new-window -t %s -n %s && tmux send-keys -t %s:%s 'rf mission-control --loop' Enter && tmux select-window -t %s:%s`,
+		sessionName, session.WindowMissionCtrl,
+		sessionName, session.WindowMissionCtrl,
+		sessionName, session.WindowIntegrator,
+	)
+
+	cmd := exec.CommandContext(context.Background(), "bash", "-c", script)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true} // Detach from parent process.
+	_ = cmd.Start()
+	// Don't wait — this runs in the background after exec replaces us.
 }
 
 func printLaunchBanner(w io.Writer) {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -16,9 +16,9 @@ const (
 	WindowMissionCtrl = "mission-control"
 )
 
-// Setup creates the Rocket Fuel tmux session.
-// Window 0 is renamed to "integrator" (no orphan window).
-// A background "mission-control" window is created for the mission control loop.
+// Setup creates the Rocket Fuel tmux session with a single "integrator" window.
+// The mission-control window should be created AFTER tmux -CC attachment
+// so iTerm2 renders it as a tab (not a separate window).
 // Returns true if a new session was created, false if one already existed.
 func Setup(tm tmux.Runner, sessionName string) (bool, error) {
 	if tm.HasSession(sessionName) {
@@ -32,17 +32,6 @@ func Setup(tm tmux.Runner, sessionName string) (bool, error) {
 	// Rename the default window (window 0) to "integrator".
 	if cli, ok := tm.(*tmux.CLI); ok {
 		_ = cli.RenameWindow(sessionName, "0", WindowIntegrator)
-	}
-
-	// Create the mission-control window for the mission control loop.
-	if err := tm.NewWindow(sessionName, WindowMissionCtrl); err != nil {
-		_ = tm.KillSession(sessionName)
-		return false, fmt.Errorf("create window %q: %w", WindowMissionCtrl, err)
-	}
-
-	// Select the integrator window so user lands there.
-	if err := tm.SelectWindow(sessionName, WindowIntegrator); err != nil {
-		return true, fmt.Errorf("select window: %w", err)
 	}
 
 	return true, nil

--- a/internal/session/session_integration_test.go
+++ b/internal/session/session_integration_test.go
@@ -45,17 +45,15 @@ func TestSetupCreatesAllWindows_Integration(t *testing.T) {
 		t.Fatal("expected session to exist after Setup")
 	}
 
-	// List windows and verify integrator + mission-control are present.
+	// Setup creates only the integrator window (window 0 renamed).
+	// Mission-control is created post-attach by cmd/up.go.
 	windows := listWindows(t, sessionName)
 
-	expected := []string{"integrator", "mission-control"}
-	for _, name := range expected {
-		if !contains(windows, name) {
-			t.Errorf("expected window %q to exist, got windows: %v", name, windows)
-		}
+	if !contains(windows, "integrator") {
+		t.Errorf("expected 'integrator' window, got: %v", windows)
 	}
-	if len(windows) != 2 {
-		t.Errorf("expected exactly 2 windows, got %d: %v", len(windows), windows)
+	if len(windows) != 1 {
+		t.Errorf("expected exactly 1 window, got %d: %v", len(windows), windows)
 	}
 }
 

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -82,7 +82,7 @@ type mockError struct{}
 
 func (e *mockError) Error() string { return "mock error" }
 
-func TestSetupCreatesSessionAndMissionControlWindow(t *testing.T) {
+func TestSetupCreatesSession(t *testing.T) {
 	t.Parallel()
 
 	tm := newMockRunner()
@@ -100,14 +100,11 @@ func TestSetupCreatesSessionAndMissionControlWindow(t *testing.T) {
 		t.Error("expected session to exist")
 	}
 
-	// Setup creates one additional window: mission-control.
-	// Window 0 (integrator) is the default from NewSession (renamed via CLI only).
+	// Setup creates only the session (window 0 = integrator).
+	// Mission-control is created post-attach by cmd/up.go.
 	windows := tm.windows["test-session"]
-	if len(windows) != 1 {
-		t.Errorf("expected 1 window created (mission-control), got %d: %v", len(windows), windows)
-	}
-	if len(windows) > 0 && windows[0] != WindowMissionCtrl {
-		t.Errorf("expected window %q, got %q", WindowMissionCtrl, windows[0])
+	if len(windows) != 0 {
+		t.Errorf("expected 0 additional windows (mission-control created post-attach), got %d: %v", len(windows), windows)
 	}
 }
 
@@ -132,19 +129,14 @@ func TestSetupIsIdempotent(t *testing.T) {
 	}
 }
 
-func TestSetupCleansUpOnWindowFailure(t *testing.T) {
+func TestSetupCleansUpOnSessionFailure(t *testing.T) {
 	t.Parallel()
 
 	tm := newMockRunner()
-	tm.failOn = "NewWindow"
+	tm.failOn = "NewSession"
 
 	_, err := Setup(tm, "fail-session")
 	if err == nil {
-		t.Fatal("expected Setup to fail when NewWindow fails")
-	}
-
-	// Session should have been killed (cleanup on partial failure).
-	if tm.sessions["fail-session"] {
-		t.Error("expected session to be cleaned up after window creation failure")
+		t.Fatal("expected Setup to fail when NewSession fails")
 	}
 }


### PR DESCRIPTION
## Summary
- Session Setup now creates only the integrator window
- Mission-control is created by a background process AFTER tmux -CC attaches
- This ensures iTerm2 renders it as a tab (not a separate window)

## Test plan
- [x] Unit + integration tests updated
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)