### PR TITLE
fix: Mission control runs in separate tmux session

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -11,7 +11,7 @@ import (
 var landCmd = &cobra.Command{
 	Use:   "land",
 	Short: "Shut down the Rocket Fuel session",
-	Long:  `Destroys the Rocket Fuel tmux session and all its windows. The rocket lands.`,
+	Long:  `Destroys both the integrator and mission control sessions. The rocket lands.`,
 	RunE:  runLand,
 }
 
@@ -21,17 +21,16 @@ func init() {
 
 func runLand(cmd *cobra.Command, _ []string) error {
 	tm := tmux.New()
-	sessionName := session.DefaultSessionName
 
-	killed, err := session.Teardown(tm, sessionName)
+	killed, err := session.TeardownAll(tm, session.DefaultSessionName)
 	if err != nil {
 		return fmt.Errorf("landing failed: %w", err)
 	}
 
 	if killed {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Rocket landed. Session %q destroyed.\n", sessionName)
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Rocket landed. All sessions destroyed.")
 	} else {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "No active session %q found.\n", sessionName)
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No active sessions found.")
 	}
 
 	return nil

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -1,11 +1,9 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"syscall"
 
@@ -22,10 +20,10 @@ import (
 var upCmd = &cobra.Command{
 	Use:   "launch",
 	Short: "Start the Rocket Fuel tmux session",
-	Long: `Creates a tmux session, launches Claude Code in the Integrator tab,
-then attaches in control mode (-CC) so iTerm2 renders native tabs.
+	Long: `Creates a tmux session with the Integrator, launches Claude Code,
+and attaches in control mode (-CC) so iTerm2 renders a native tab.
 
-Mission control starts as a background tab after attachment.
+Mission control runs in a separate background session.
 If a session already exists, attaches to it without relaunching.`,
 	RunE: runUp,
 }
@@ -63,10 +61,12 @@ func runUp(cmd *cobra.Command, _ []string) error {
 			_, _ = fmt.Fprintf(out, "  Warning: could not launch integrator: %v\n", launchErr)
 		}
 
-		// Start a background process that creates mission-control AFTER
-		// tmux -CC attaches. This ensures iTerm2 sees the window creation
-		// as a live event and renders it as a tab, not a separate window.
-		spawnPostAttachSetup(sessionName)
+		// Start mission control in a separate detached session.
+		if mcCreated, mcErr := session.SetupMissionControl(tm); mcErr != nil {
+			_, _ = fmt.Fprintf(out, "  Warning: could not start mission control: %v\n", mcErr)
+		} else if mcCreated {
+			_ = tm.SendKeys(session.MissionControlSession, session.WindowMissionCtrl, "rf mission-control --loop")
+		}
 
 		_, _ = fmt.Fprintln(out)
 	} else {
@@ -87,36 +87,15 @@ func runUp(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-// spawnPostAttachSetup starts a detached background process that waits for -CC
-// attachment, then creates the mission-control window and launches heartbeat.
-// This must be a separate process because syscall.Exec replaces the current one.
-func spawnPostAttachSetup(sessionName string) {
-	// Shell script that waits for -CC to attach, then creates the window.
-	script := fmt.Sprintf(
-		`sleep 2 && tmux new-window -t %s -n %s && tmux send-keys -t %s:%s 'rf mission-control --loop' Enter && tmux select-window -t %s:%s`,
-		sessionName, session.WindowMissionCtrl,
-		sessionName, session.WindowMissionCtrl,
-		sessionName, session.WindowIntegrator,
-	)
-
-	cmd := exec.CommandContext(context.Background(), "bash", "-c", script)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true} // Detach from parent process.
-	_ = cmd.Start()
-	// Don't wait — this runs in the background after exec replaces us.
-}
-
 func printLaunchBanner(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "Rocket Fuel")
 	_, _ = fmt.Fprintln(w)
 
-	// Show repo info.
 	if repoDir, err := repoRoot(); err == nil {
 		_, _ = fmt.Fprintf(w, "  Repo:    %s\n", filepath.Base(repoDir))
 	}
 
-	// Show project info.
 	if cfg, err := loadProjectConfig(); err == nil {
-		// Try to fetch the board to get the project title.
 		if board, fetchErr := project.FetchBoard(cfg.Owner, cfg.ProjectNumber); fetchErr == nil && board.ProjectTitle != "" {
 			_, _ = fmt.Fprintf(w, "  Project: %s (#%d)\n", board.ProjectTitle, cfg.ProjectNumber)
 		} else {
@@ -140,13 +119,11 @@ func launchIntegrator(tm tmux.Runner, sessionName string) error {
 		Branch:  primeCurrentBranch(),
 	}
 
-	// Load integrator prompt.
 	promptPath := filepath.Join(repoDir, "prompts", "integrator.md")
 	if data, readErr := os.ReadFile(promptPath); readErr == nil {
 		in.IntegratorPrompt = string(data)
 	}
 
-	// Load board state (optional).
 	if cfg, loadErr := loadProjectConfig(); loadErr == nil {
 		board, fetchErr := project.FetchBoard(cfg.Owner, cfg.ProjectNumber)
 		if fetchErr == nil {
@@ -154,13 +131,11 @@ func launchIntegrator(tm tmux.Runner, sessionName string) error {
 		}
 	}
 
-	// Load worker status (optional).
 	s, gatherErr := status.Gather(tm, sessionName, repoDir)
 	if gatherErr == nil {
 		in.Status = s
 	}
 
-	// Write context file and launch Claude.
 	contextPath, err := launch.WritePrimeContext(repoDir, in)
 	if err != nil {
 		return err
@@ -183,8 +158,6 @@ func selfUpdate(w io.Writer) {
 
 	if result.Updated {
 		_, _ = fmt.Fprintf(w, "  Updated rf: %s -> %s\n", result.OldVersion, result.NewVersion)
-		// Re-exec the new binary with the same args.
 		_ = syscall.Exec(binaryPath, os.Args, os.Environ())
-		// If exec fails, continue with current binary.
 	}
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -10,15 +10,16 @@ import (
 // DefaultSessionName is the tmux session name used by Rocket Fuel.
 const DefaultSessionName = "rocket-fuel"
 
-// Window names for the Rocket Fuel session.
+// MissionControlSession is the separate tmux session for mission control.
+const MissionControlSession = "rf-mission-control"
+
+// Window names.
 const (
 	WindowIntegrator  = "integrator"
 	WindowMissionCtrl = "mission-control"
 )
 
 // Setup creates the Rocket Fuel tmux session with a single "integrator" window.
-// The mission-control window should be created AFTER tmux -CC attachment
-// so iTerm2 renders it as a tab (not a separate window).
 // Returns true if a new session was created, false if one already existed.
 func Setup(tm tmux.Runner, sessionName string) (bool, error) {
 	if tm.HasSession(sessionName) {
@@ -35,4 +36,41 @@ func Setup(tm tmux.Runner, sessionName string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// SetupMissionControl creates a separate detached tmux session for mission control.
+// Returns true if created, false if already running.
+func SetupMissionControl(tm tmux.Runner) (bool, error) {
+	if tm.HasSession(MissionControlSession) {
+		return false, nil
+	}
+
+	if err := tm.NewSession(MissionControlSession); err != nil {
+		return false, fmt.Errorf("create mission control session: %w", err)
+	}
+
+	if cli, ok := tm.(*tmux.CLI); ok {
+		_ = cli.RenameWindow(MissionControlSession, "0", WindowMissionCtrl)
+	}
+
+	return true, nil
+}
+
+// TeardownAll kills both the main session and mission control.
+func TeardownAll(tm tmux.Runner, sessionName string) (bool, error) {
+	killed := false
+
+	if tm.HasSession(MissionControlSession) {
+		_ = tm.KillSession(MissionControlSession)
+		killed = true
+	}
+
+	if tm.HasSession(sessionName) {
+		if err := tm.KillSession(sessionName); err != nil {
+			return killed, fmt.Errorf("kill session: %w", err)
+		}
+		killed = true
+	}
+
+	return killed, nil
 }


### PR DESCRIPTION
## Summary
- Mission control now runs in its own detached session (rf-mission-control)
- User sees ONE tab — the integrator
- rf land kills both sessions
- Fixes incomplete merge from #84

## Test plan
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)