### PR TITLE
feat: Use SessionStart hook for integrator context (gastown pattern)

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -8,11 +8,9 @@ import (
 	"syscall"
 
 	"github.com/drdanmaggs/rocket-fuel/internal/launch"
-	"github.com/drdanmaggs/rocket-fuel/internal/prime"
 	"github.com/drdanmaggs/rocket-fuel/internal/project"
 	"github.com/drdanmaggs/rocket-fuel/internal/selfupdate"
 	"github.com/drdanmaggs/rocket-fuel/internal/session"
-	"github.com/drdanmaggs/rocket-fuel/internal/status"
 	"github.com/drdanmaggs/rocket-fuel/internal/tmux"
 	"github.com/spf13/cobra"
 )
@@ -23,8 +21,8 @@ var upCmd = &cobra.Command{
 	Long: `Creates a tmux session with the Integrator, launches Claude Code,
 and attaches in control mode (-CC) so iTerm2 renders a native tab.
 
-Mission control runs in a separate background session.
-If a session already exists, attaches to it without relaunching.`,
+Claude gets its context via a SessionStart hook that runs rf prime.
+Mission control runs in a separate background session.`,
 	RunE: runUp,
 }
 
@@ -37,7 +35,8 @@ func runUp(cmd *cobra.Command, _ []string) error {
 	out := cmd.OutOrStdout()
 
 	// Pre-flight: must be in a git repo.
-	if _, err := repoRoot(); err != nil {
+	repoDir, err := repoRoot()
+	if err != nil {
 		return fmt.Errorf("not in a git repository — cd into your project first")
 	}
 
@@ -56,9 +55,16 @@ func runUp(cmd *cobra.Command, _ []string) error {
 	}
 
 	if created {
-		// Launch Claude Code in the integrator window with prime context.
-		if launchErr := launchIntegrator(tm, sessionName); launchErr != nil {
-			_, _ = fmt.Fprintf(out, "  Warning: could not launch integrator: %v\n", launchErr)
+		// Ensure .claude/settings.json has the SessionStart hook.
+		if err := launch.EnsureClaudeSettings(repoDir); err != nil {
+			_, _ = fmt.Fprintf(out, "  Warning: could not set up Claude hooks: %v\n", err)
+		}
+
+		// Launch Claude Code in the integrator window.
+		// Context is injected automatically via the SessionStart hook (rf prime).
+		launchCmd := launch.IntegratorCommand()
+		if err := tm.SendKeys(sessionName, session.WindowIntegrator, launchCmd); err != nil {
+			_, _ = fmt.Fprintf(out, "  Warning: could not launch integrator: %v\n", err)
 		}
 
 		// Start mission control in a separate detached session.
@@ -106,39 +112,6 @@ func printLaunchBanner(w io.Writer) {
 	}
 
 	_, _ = fmt.Fprintln(w)
-}
-
-func launchIntegrator(tm tmux.Runner, sessionName string) error {
-	repoDir, err := repoRoot()
-	if err != nil {
-		return fmt.Errorf("find repo root: %w", err)
-	}
-
-	in := &prime.Input{
-		RepoDir: repoDir,
-		Branch:  primeCurrentBranch(),
-		// IntegratorPrompt left empty — prime.Build uses the embedded default.
-	}
-
-	if cfg, loadErr := loadProjectConfig(); loadErr == nil {
-		board, fetchErr := project.FetchBoard(cfg.Owner, cfg.ProjectNumber)
-		if fetchErr == nil {
-			in.Board = board
-		}
-	}
-
-	s, gatherErr := status.Gather(tm, sessionName, repoDir)
-	if gatherErr == nil {
-		in.Status = s
-	}
-
-	contextPath, err := launch.WritePrimeContext(repoDir, in)
-	if err != nil {
-		return err
-	}
-
-	launchCmd := launch.IntegratorCommand(contextPath)
-	return tm.SendKeys(sessionName, "integrator", launchCmd)
 }
 
 func selfUpdate(w io.Writer) {

--- a/internal/launch/launch.go
+++ b/internal/launch/launch.go
@@ -2,6 +2,7 @@
 package launch
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,13 +11,66 @@ import (
 	"github.com/drdanmaggs/rocket-fuel/internal/prime"
 )
 
-// WindowCommand pairs a window name with the command to run in it.
-type WindowCommand struct {
-	Window  string
-	Command string
+// EnsureClaudeSettings creates or updates .claude/settings.json in the project
+// with the SessionStart hook that runs rf prime. This is how the Integrator
+// gets its context — same pattern as gastown's gt prime --hook.
+func EnsureClaudeSettings(repoDir string) error {
+	claudeDir := filepath.Join(repoDir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		return fmt.Errorf("create .claude dir: %w", err)
+	}
+
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+
+	// Read existing settings if they exist.
+	settings := make(map[string]interface{})
+	if data, err := os.ReadFile(settingsPath); err == nil {
+		_ = json.Unmarshal(data, &settings)
+	}
+
+	// Ensure hooks exist.
+	hooks, _ := settings["hooks"].(map[string]interface{})
+	if hooks == nil {
+		hooks = make(map[string]interface{})
+	}
+
+	// Set SessionStart hook to run rf prime.
+	hooks["SessionStart"] = []map[string]interface{}{
+		{
+			"matcher": "",
+			"hooks": []map[string]interface{}{
+				{
+					"type":    "command",
+					"command": fmt.Sprintf("export PATH=\"$HOME/go/bin:$PATH\" && rf prime"),
+				},
+			},
+		},
+	}
+
+	// Set PreCompact hook to re-inject context after compression.
+	hooks["PreCompact"] = []map[string]interface{}{
+		{
+			"matcher": "",
+			"hooks": []map[string]interface{}{
+				{
+					"type":    "command",
+					"command": fmt.Sprintf("export PATH=\"$HOME/go/bin:$PATH\" && rf prime"),
+				},
+			},
+		},
+	}
+
+	settings["hooks"] = hooks
+
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal settings: %w", err)
+	}
+
+	return os.WriteFile(settingsPath, data, 0o644)
 }
 
-// WritePrimeContext writes the prime context to a file for claude --system-prompt.
+// WritePrimeContext writes the prime context to a file.
 // Returns the file path.
 func WritePrimeContext(repoDir string, input *prime.Input) (string, error) {
 	dir := filepath.Join(repoDir, ".rocket-fuel")
@@ -35,9 +89,8 @@ func WritePrimeContext(repoDir string, input *prime.Input) (string, error) {
 }
 
 // IntegratorCommand returns the claude launch command for the integrator window.
-// Uses --system-prompt with $(cat <file>) to load the context from disk.
-func IntegratorCommand(contextFilePath string) string {
-	return fmt.Sprintf("claude --system-prompt \"$(cat %s)\"", shellQuote(contextFilePath))
+func IntegratorCommand() string {
+	return "claude --dangerously-skip-permissions"
 }
 
 // shellQuote wraps a string in single quotes, escaping any embedded single quotes.

--- a/internal/launch/launch_test.go
+++ b/internal/launch/launch_test.go
@@ -1,6 +1,7 @@
 package launch
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -43,31 +44,84 @@ func TestWritePrimeContext_createsFile(t *testing.T) {
 	}
 }
 
-func TestIntegratorCommand_usesSystemPrompt(t *testing.T) {
+func TestIntegratorCommand_usesDangerouslySkipPermissions(t *testing.T) {
 	t.Parallel()
 
-	cmd := IntegratorCommand("/tmp/context.md")
+	cmd := IntegratorCommand()
 
-	if !strings.Contains(cmd, "--system-prompt") {
-		t.Errorf("expected --system-prompt flag, got: %q", cmd)
+	if !strings.Contains(cmd, "claude") {
+		t.Errorf("expected claude command, got: %q", cmd)
 	}
-	if !strings.Contains(cmd, "$(cat") {
-		t.Errorf("expected $(cat ...) to read file, got: %q", cmd)
-	}
-	if !strings.Contains(cmd, "/tmp/context.md") {
-		t.Errorf("expected file path in command, got: %q", cmd)
+	if !strings.Contains(cmd, "--dangerously-skip-permissions") {
+		t.Errorf("expected --dangerously-skip-permissions, got: %q", cmd)
 	}
 }
 
-func TestIntegratorCommand_quotesPathWithSpaces(t *testing.T) {
+func TestEnsureClaudeSettings_createsSettingsFile(t *testing.T) {
 	t.Parallel()
 
-	cmd := IntegratorCommand("/home/user/my projects/.rocket-fuel/integrator-context.md")
-
-	if !strings.Contains(cmd, "'") {
-		t.Errorf("expected quoted path for spaces, got: %q", cmd)
+	dir := t.TempDir()
+	err := EnsureClaudeSettings(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(cmd, "my projects") {
-		t.Errorf("expected full path preserved, got: %q", cmd)
+
+	data, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("settings file not created: %v", err)
+	}
+
+	var settings map[string]interface{}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	// Verify SessionStart hook exists with rf prime.
+	hooks, ok := settings["hooks"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected hooks in settings")
+	}
+
+	sessionStart, ok := hooks["SessionStart"]
+	if !ok {
+		t.Fatal("expected SessionStart hook")
+	}
+
+	raw, _ := json.Marshal(sessionStart)
+	if !strings.Contains(string(raw), "rf prime") {
+		t.Errorf("expected SessionStart hook to contain 'rf prime', got: %s", raw)
+	}
+}
+
+func TestEnsureClaudeSettings_preservesExistingSettings(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write existing settings with a custom field.
+	existing := `{"customField": "preserve-me"}`
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := EnsureClaudeSettings(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(data), "preserve-me") {
+		t.Error("expected existing settings to be preserved")
+	}
+	if !strings.Contains(string(data), "rf prime") {
+		t.Error("expected SessionStart hook to be added")
 	}
 }


### PR DESCRIPTION
## Summary
- Context injected via Claude Code SessionStart hook (rf prime), not --system-prompt
- PreCompact hook re-injects after context compression
- Claude launches with --dangerously-skip-permissions
- .claude/settings.json created in the project automatically
- Preserves existing settings when adding hooks
- Matches gastown's `gt prime --hook` pattern

Closes #88
Closes #87

## Test plan
- [x] EnsureClaudeSettings creates settings file with hooks
- [x] Preserves existing settings when adding hooks
- [x] IntegratorCommand uses --dangerously-skip-permissions
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)