### PR TITLE
fix: Send initial prompt so Integrator acts immediately

### DIFF
--- a/internal/launch/launch.go
+++ b/internal/launch/launch.go
@@ -89,8 +89,9 @@ func WritePrimeContext(repoDir string, input *prime.Input) (string, error) {
 }
 
 // IntegratorCommand returns the claude launch command for the integrator window.
+// Includes an initial prompt so Claude acts immediately on the injected context.
 func IntegratorCommand() string {
-	return "claude --dangerously-skip-permissions"
+	return `claude --dangerously-skip-permissions "You are the Integrator. Your context has been loaded via the SessionStart hook. Review the board state and act on your startup instructions immediately."`
 }
 
 // shellQuote wraps a string in single quotes, escaping any embedded single quotes.


### PR DESCRIPTION
## Summary
- Claude gets context via SessionStart hook but waits for user input
- Added initial prompt so Claude acts on its context immediately

## Test plan
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)