### PR TITLE
fix: Workers use own tmux sessions, fix prompt flag, add skip-permissions

### DIFF
--- a/internal/launch/launch.go
+++ b/internal/launch/launch.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/drdanmaggs/rocket-fuel/internal/prime"
 )
@@ -41,7 +40,7 @@ func EnsureClaudeSettings(repoDir string) error {
 			"hooks": []map[string]interface{}{
 				{
 					"type":    "command",
-					"command": fmt.Sprintf("export PATH=\"$HOME/go/bin:$PATH\" && rf prime"),
+					"command": `export PATH="$HOME/go/bin:$PATH" && rf prime`,
 				},
 			},
 		},
@@ -54,7 +53,7 @@ func EnsureClaudeSettings(repoDir string) error {
 			"hooks": []map[string]interface{}{
 				{
 					"type":    "command",
-					"command": fmt.Sprintf("export PATH=\"$HOME/go/bin:$PATH\" && rf prime"),
+					"command": `export PATH="$HOME/go/bin:$PATH" && rf prime`,
 				},
 			},
 		},
@@ -92,9 +91,4 @@ func WritePrimeContext(repoDir string, input *prime.Input) (string, error) {
 // Includes an initial prompt so Claude acts immediately on the injected context.
 func IntegratorCommand() string {
 	return `claude --dangerously-skip-permissions "You are the Integrator. Your context has been loaded via the SessionStart hook. Review the board state and act on your startup instructions immediately."`
-}
-
-// shellQuote wraps a string in single quotes, escaping any embedded single quotes.
-func shellQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -57,14 +57,27 @@ func SetupMissionControl(tm tmux.Runner) (bool, error) {
 }
 
 // TeardownAll kills both the main session and mission control.
+// TeardownAll kills the integrator, mission control, and all worker sessions.
 func TeardownAll(tm tmux.Runner, sessionName string) (bool, error) {
 	killed := false
 
+	// Kill worker sessions (rf-worker-*).
+	if cli, ok := tm.(*tmux.CLI); ok {
+		for _, ws := range cli.ListSessions() {
+			if len(ws) > 10 && ws[:10] == "rf-worker-" {
+				_ = tm.KillSession(ws)
+				killed = true
+			}
+		}
+	}
+
+	// Kill mission control.
 	if tm.HasSession(MissionControlSession) {
 		_ = tm.KillSession(MissionControlSession)
 		killed = true
 	}
 
+	// Kill integrator.
 	if tm.HasSession(sessionName) {
 		if err := tm.KillSession(sessionName); err != nil {
 			return killed, fmt.Errorf("kill session: %w", err)

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -52,9 +52,13 @@ func Gather(tm tmux.Runner, sessionName, repoDir string) (*Summary, error) {
 		name := entry.Name()
 		worktreeDir := filepath.Join(worktreesDir, name)
 
+		// Workers run in their own sessions (rf-worker-<number>).
+		issueNum := strings.TrimPrefix(name, "worker-")
+		workerSession := "rf-worker-" + issueNum
+
 		ws := WorkerStatus{
 			Name:       name,
-			WindowOpen: s.SessionActive && tm.HasWindow(sessionName, name),
+			WindowOpen: tm.HasSession(workerSession),
 			Branch:     worktreeBranch(worktreeDir),
 		}
 

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -78,7 +78,9 @@ func TestGatherWithWorkers(t *testing.T) {
 
 	tm := newMockRunner()
 	tm.sessions["rocket-fuel"] = true
-	tm.windows["rocket-fuel"] = map[string]bool{"worker-1": true}
+	// Worker-1 has its own session (active).
+	tm.sessions["rf-worker-1"] = true
+	// Worker-2 has no session (completed).
 
 	s, err := Gather(tm, "rocket-fuel", repoDir)
 	if err != nil {
@@ -89,14 +91,14 @@ func TestGatherWithWorkers(t *testing.T) {
 		t.Fatalf("expected 2 workers, got %d", len(s.Workers))
 	}
 
-	// worker-1 should be active (window exists).
+	// worker-1 should be active (session exists).
 	if !s.Workers[0].WindowOpen {
-		t.Error("expected worker-1 window to be open")
+		t.Error("expected worker-1 to be active")
 	}
 
-	// worker-2 should be done (no window).
+	// worker-2 should be done (no session).
 	if s.Workers[1].WindowOpen {
-		t.Error("expected worker-2 window to be closed")
+		t.Error("expected worker-2 to be done")
 	}
 }
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -100,6 +100,18 @@ func (c *CLI) AttachCC(session string) error {
 	return syscall.Exec(tmuxPath, args, os.Environ())
 }
 
+// ListSessions returns the names of all tmux sessions.
+func (c *CLI) ListSessions() []string {
+	out, err := c.output("list-sessions", "-F", "#{session_name}")
+	if err != nil {
+		return nil
+	}
+	if out == "" {
+		return nil
+	}
+	return strings.Split(out, "\n")
+}
+
 // RenameWindow changes the name of a window in a session.
 // Target can be a window name or index (e.g., "0" for the first window).
 func (c *CLI) RenameWindow(session, target, newName string) error {

--- a/internal/worker/reap.go
+++ b/internal/worker/reap.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/drdanmaggs/rocket-fuel/internal/tmux"
 )
@@ -18,16 +19,16 @@ type ReapResult struct {
 	Reason      string
 }
 
-// Reap finds completed workers and cleans up their worktrees and tmux windows.
-// A worker is considered complete when its tmux window no longer exists
+// Reap finds completed workers and cleans up their worktrees and tmux sessions.
+// A worker is considered complete when its tmux session no longer exists
 // (Claude Code session ended).
-func Reap(tm tmux.Runner, sessionName, repoDir string) ([]ReapResult, error) {
+func Reap(tm tmux.Runner, _, repoDir string) ([]ReapResult, error) {
 	worktreesDir := filepath.Join(repoDir, ".worktrees")
 
 	entries, err := os.ReadDir(worktreesDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil // no worktrees directory = nothing to reap
+			return nil, nil
 		}
 		return nil, fmt.Errorf("read worktrees dir: %w", err)
 	}
@@ -42,20 +43,24 @@ func Reap(tm tmux.Runner, sessionName, repoDir string) ([]ReapResult, error) {
 		name := entry.Name() // e.g. "worker-42"
 		worktreeDir := filepath.Join(worktreesDir, name)
 
-		// Check if the tmux window still exists.
-		windowExists := tm.HasSession(sessionName) && hasWindow(tm, sessionName, name)
+		// Extract issue number from worker name to find the session.
+		issueNum := strings.TrimPrefix(name, "worker-")
+		workerSession := "rf-worker-" + issueNum
 
-		if windowExists {
+		// Check if the worker's tmux session still exists.
+		sessionExists := tm.HasSession(workerSession)
+
+		if sessionExists {
 			results = append(results, ReapResult{
 				WindowName:  name,
 				WorktreeDir: worktreeDir,
 				Reaped:      false,
-				Reason:      "window still active",
+				Reason:      "session still active",
 			})
 			continue
 		}
 
-		// Window is gone — clean up the worktree.
+		// Session is gone — clean up the worktree.
 		if err := removeWorktree(repoDir, worktreeDir); err != nil {
 			results = append(results, ReapResult{
 				WindowName:  name,
@@ -74,14 +79,9 @@ func Reap(tm tmux.Runner, sessionName, repoDir string) ([]ReapResult, error) {
 		})
 	}
 
-	// Prune stale worktree references.
 	_ = pruneWorktrees(repoDir)
 
 	return results, nil
-}
-
-func hasWindow(tm tmux.Runner, session, window string) bool {
-	return tm.HasWindow(session, window)
 }
 
 func removeWorktree(repoDir, worktreeDir string) error {

--- a/internal/worker/reap_test.go
+++ b/internal/worker/reap_test.go
@@ -9,7 +9,7 @@ import (
 // mockTmuxRunner for reap tests.
 type mockTmuxRunner struct {
 	sessions map[string]bool
-	windows  map[string]map[string]bool // session -> window -> exists
+	windows  map[string]map[string]bool
 }
 
 func newMockTmuxRunner() *mockTmuxRunner {
@@ -66,7 +66,6 @@ func (e *mockSelectError) Error() string { return "window not found" }
 func TestReapCleansUpCompletedWorkers(t *testing.T) {
 	t.Parallel()
 
-	// Set up a fake repo with a worktrees directory.
 	repoDir := t.TempDir()
 	worktreesDir := filepath.Join(repoDir, ".worktrees")
 
@@ -74,9 +73,8 @@ func TestReapCleansUpCompletedWorkers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// tmux has no window for worker-42 (session ended).
+	// No rf-worker-42 session exists (worker finished).
 	tm := newMockTmuxRunner()
-	tm.sessions["rocket-fuel"] = true
 
 	results, err := Reap(tm, "rocket-fuel", repoDir)
 	if err != nil {
@@ -87,8 +85,6 @@ func TestReapCleansUpCompletedWorkers(t *testing.T) {
 		t.Fatalf("expected 1 result, got %d", len(results))
 	}
 
-	// The worktree dir was just a plain dir (not a real worktree),
-	// so git worktree remove will fail, but we still get a result.
 	r := results[0]
 	if r.WindowName != "worker-42" {
 		t.Errorf("expected window name 'worker-42', got %q", r.WindowName)
@@ -105,10 +101,9 @@ func TestReapSkipsActiveWorkers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// tmux HAS the window for worker-99 (still active).
+	// rf-worker-99 session exists (still active).
 	tm := newMockTmuxRunner()
-	tm.sessions["rocket-fuel"] = true
-	_ = tm.NewWindow("rocket-fuel", "worker-99")
+	tm.sessions["rf-worker-99"] = true
 
 	results, err := Reap(tm, "rocket-fuel", repoDir)
 	if err != nil {
@@ -123,8 +118,8 @@ func TestReapSkipsActiveWorkers(t *testing.T) {
 	if r.Reaped {
 		t.Error("expected active worker to NOT be reaped")
 	}
-	if r.Reason != "window still active" {
-		t.Errorf("expected reason 'window still active', got %q", r.Reason)
+	if r.Reason != "session still active" {
+		t.Errorf("expected reason 'session still active', got %q", r.Reason)
 	}
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -22,35 +22,46 @@ type Issue struct {
 // SpawnConfig holds configuration for spawning a worker.
 type SpawnConfig struct {
 	RepoDir     string // root of the git repo
-	SessionName string // tmux session to create window in
+	SessionName string // parent session name (used for naming convention only)
 }
 
-// Spawn creates a git worktree, tmux window, and launches Claude Code for an issue.
+// Spawn creates a git worktree, its own tmux session, and launches Claude Code for an issue.
+// Each worker gets an isolated tmux session (rf-worker-<number>), not a window in the integrator.
 func Spawn(tm tmux.Runner, cfg SpawnConfig, issue Issue) error {
 	branchName := fmt.Sprintf("rf/issue-%d", issue.Number)
 	worktreeDir := filepath.Join(cfg.RepoDir, ".worktrees", fmt.Sprintf("worker-%d", issue.Number))
-	windowName := fmt.Sprintf("worker-%d", issue.Number)
+	sessionName := fmt.Sprintf("rf-worker-%d", issue.Number)
 
 	// Create git worktree.
 	if err := createWorktree(cfg.RepoDir, worktreeDir, branchName); err != nil {
 		return fmt.Errorf("create worktree: %w", err)
 	}
 
-	// Create tmux window.
-	if err := tm.NewWindow(cfg.SessionName, windowName); err != nil {
-		return fmt.Errorf("create window: %w", err)
+	// Create a dedicated tmux session for this worker.
+	if err := tm.NewSession(sessionName); err != nil {
+		return fmt.Errorf("create worker session: %w", err)
 	}
 
-	// Send commands to the new window: cd into worktree and launch claude.
+	// Rename window 0 to the worker name.
+	if cli, ok := tm.(*tmux.CLI); ok {
+		_ = cli.RenameWindow(sessionName, "0", fmt.Sprintf("worker-%d", issue.Number))
+	}
+
+	// Send commands: cd into worktree and launch claude with the prompt.
 	skill := routeSkill(issue.Labels)
 	prompt := buildPrompt(issue, skill)
 
-	sendKeys := fmt.Sprintf("cd %s && claude --prompt %s", worktreeDir, shellQuote(prompt))
-	if err := tmuxSendKeys(tm, cfg.SessionName, windowName, sendKeys); err != nil {
+	sendKeys := fmt.Sprintf("cd %s && claude --dangerously-skip-permissions %s", worktreeDir, shellQuote(prompt))
+	if err := tm.SendKeys(sessionName, fmt.Sprintf("worker-%d", issue.Number), sendKeys); err != nil {
 		return fmt.Errorf("send keys: %w", err)
 	}
 
 	return nil
+}
+
+// SessionName returns the tmux session name for a worker.
+func SessionName(issueNumber int) string {
+	return fmt.Sprintf("rf-worker-%d", issueNumber)
 }
 
 // routeSkill determines which skill to use based on issue labels.
@@ -105,11 +116,6 @@ func createWorktree(repoDir, worktreeDir, branchName string) error {
 	return nil
 }
 
-func tmuxSendKeys(tm tmux.Runner, session, window, keys string) error {
-	return tm.SendKeys(session, window, keys)
-}
-
 func shellQuote(s string) string {
-	// Single-quote the string, escaping any existing single quotes.
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }


### PR DESCRIPTION
## Summary
- Workers spawn in isolated tmux sessions (rf-worker-<number>), not integrator tabs
- Fixed: `--prompt` → positional argument (Claude CLI doesn't have --prompt)
- Added `--dangerously-skip-permissions` for autonomous worker operation
- Reap/status detect workers via session existence, not window existence
- `rf land` kills all sessions (integrator + mission-control + all workers)
- Added `ListSessions()` to tmux.CLI for session discovery

Closes #93
Closes #94

## Test plan
- [x] Reap tests updated for session-based detection
- [x] Status tests updated for session-based detection
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)