### PR TITLE
fix: Handle stale branches on spawn + skip failed issues in dispatch

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -23,6 +23,10 @@ func repoRoot() (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// dispatchFailedIssues tracks issues that failed to spawn.
+// Persists across heartbeat cycles to avoid infinite retries.
+var dispatchFailedIssues = make(map[int]bool)
+
 // runDispatchCycle executes one dispatch cycle: fetch board, check capacity, spawn.
 // Used by both the dispatch command and the mission control loop.
 func runDispatchCycle(dryRun bool) (*dispatch.Result, error) {
@@ -84,5 +88,6 @@ func runDispatchCycle(dryRun bool) (*dispatch.Result, error) {
 		ActiveWorkers:  activeWorkers,
 		SpawnFunc:      spawnFn,
 		TransitionFunc: transitionFn,
+		FailedIssues:   dispatchFailedIssues,
 	})
 }

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -25,6 +25,7 @@ type Deps struct {
 	ActiveWorkers  int
 	SpawnFunc      SpawnFunc
 	TransitionFunc TransitionFunc
+	FailedIssues   map[int]bool // issues that failed to spawn — skip on retry
 }
 
 // Result describes what happened during a dispatch cycle.
@@ -35,10 +36,10 @@ type Result struct {
 	Reason      string
 }
 
-// Run executes one dispatch cycle: check for Scoped items, check capacity, spawn.
+// Run executes one dispatch cycle: check for Ready items, check capacity, spawn.
 func Run(cfg Config, deps Deps) (*Result, error) {
-	// Check for Scoped items.
-	next := project.NextReady(deps.Board)
+	// Find next ready item, skipping previously failed issues.
+	next := nextDispatchable(deps.Board, deps.FailedIssues)
 	if next == nil {
 		return &Result{Reason: "nothing to dispatch"}, nil
 	}
@@ -53,6 +54,10 @@ func Run(cfg Config, deps Deps) (*Result, error) {
 	// Spawn worker.
 	if deps.SpawnFunc != nil {
 		if err := deps.SpawnFunc(next.Number); err != nil {
+			// Track the failure so we don't retry next cycle.
+			if deps.FailedIssues != nil {
+				deps.FailedIssues[next.Number] = true
+			}
 			return nil, fmt.Errorf("spawn worker for #%d: %w", next.Number, err)
 		}
 	}
@@ -76,4 +81,18 @@ func Run(cfg Config, deps Deps) (*Result, error) {
 		WorkerName:  fmt.Sprintf("worker-%d", next.Number),
 		Reason:      fmt.Sprintf("dispatched #%d", next.Number),
 	}, nil
+}
+
+// nextDispatchable returns the first Ready item that hasn't previously failed.
+func nextDispatchable(board *project.BoardSummary, failed map[int]bool) *project.Item {
+	for _, name := range project.ReadyColumnNames() {
+		items := board.Columns[name]
+		for i := range items {
+			if failed != nil && failed[items[i].Number] {
+				continue
+			}
+			return &items[i]
+		}
+	}
+	return nil
 }

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -84,6 +84,11 @@ func FetchBoard(run GHRunner, owner string, projectNumber int) (*BoardSummary, e
 // GitHub's default Kanban uses "Ready". Rocket Fuel docs use "Scoped".
 var readyColumnNames = []string{"Ready", "Scoped"}
 
+// ReadyColumnNames returns the list of column names checked for ready items.
+func ReadyColumnNames() []string {
+	return readyColumnNames
+}
+
 // NextReady returns the highest-priority issue from the ready column.
 // Checks for "Ready" (GitHub default) and "Scoped" (Rocket Fuel convention).
 // Returns nil if no ready issues are available.

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -97,7 +97,21 @@ func createWorktree(repoDir, worktreeDir, branchName string) error {
 	cmd.Dir = repoDir
 
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("%w\n%s", err, out)
+		// If branch already exists, clean up stale state and retry.
+		if strings.Contains(string(out), "already exists") {
+			cleanupStaleWorker(repoDir, worktreeDir, branchName)
+			// Retry once.
+			retry := exec.CommandContext(
+				context.Background(),
+				"git", "worktree", "add", "-b", branchName, worktreeDir,
+			)
+			retry.Dir = repoDir
+			if retryOut, retryErr := retry.CombinedOutput(); retryErr != nil {
+				return fmt.Errorf("%w\n%s", retryErr, retryOut)
+			}
+		} else {
+			return fmt.Errorf("%w\n%s", err, out)
+		}
 	}
 
 	// Configure git hooks in the new worktree.
@@ -106,6 +120,26 @@ func createWorktree(repoDir, worktreeDir, branchName string) error {
 	_ = setup.Run() // best-effort — don't fail spawn if make setup fails
 
 	return nil
+}
+
+// cleanupStaleWorker removes a stale worktree and branch from a previous failed spawn.
+func cleanupStaleWorker(repoDir, worktreeDir, branchName string) {
+	ctx := context.Background()
+
+	// Remove worktree if it exists.
+	remove := exec.CommandContext(ctx, "git", "worktree", "remove", "--force", worktreeDir)
+	remove.Dir = repoDir
+	_ = remove.Run()
+
+	// Prune stale worktree entries.
+	prune := exec.CommandContext(ctx, "git", "worktree", "prune")
+	prune.Dir = repoDir
+	_ = prune.Run()
+
+	// Delete the stale branch.
+	deleteBranch := exec.CommandContext(ctx, "git", "branch", "-D", branchName)
+	deleteBranch.Dir = repoDir
+	_ = deleteBranch.Run()
 }
 
 func shellQuote(s string) string {


### PR DESCRIPTION
## Summary
- Spawn handles "branch already exists" by cleaning up stale worktree/branch and retrying
- Dispatch tracks failed issues and skips them on subsequent cycles
- Prevents infinite retry loop in mission control

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)