### PR TITLE
feat: Split-pane dashboard in integrator tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin/
 .worktrees/
 .rocket-fuel/
+rocket-fuel

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/drdanmaggs/rocket-fuel/internal/dashboard"
+	"github.com/drdanmaggs/rocket-fuel/internal/session"
+	"github.com/drdanmaggs/rocket-fuel/internal/status"
+	"github.com/drdanmaggs/rocket-fuel/internal/tmux"
+	"github.com/spf13/cobra"
+)
+
+var dashboardCmd = &cobra.Command{
+	Use:    "dashboard",
+	Hidden: true, // internal — launched by rf launch in the split pane
+	Short:  "Live status dashboard for the split pane",
+	RunE:   runDashboard,
+}
+
+func init() {
+	rootCmd.AddCommand(dashboardCmd)
+}
+
+func runDashboard(cmd *cobra.Command, _ []string) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+
+	// Render immediately.
+	renderDashboard(cmd)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			renderDashboard(cmd)
+		}
+	}
+}
+
+func renderDashboard(cmd *cobra.Command) {
+	repoDir, err := repoRoot()
+	if err != nil {
+		return
+	}
+
+	tm := tmux.New()
+	sessionName := session.DefaultSessionName
+
+	s, err := status.Gather(tm, sessionName, repoDir)
+	if err != nil {
+		return
+	}
+
+	// Clear screen and render.
+	_, _ = fmt.Fprint(cmd.OutOrStdout(), "\033[2J\033[H")
+	_, _ = fmt.Fprint(cmd.OutOrStdout(), dashboard.Render(s))
+}

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -67,7 +67,18 @@ func renderDashboard(cmd *cobra.Command) {
 		return
 	}
 
+	// Read recent activity log.
+	activityLines := dashboard.ReadActivity(repoDir, 5)
+
+	// Read pending merges.
+	pendingMerges := dashboard.ListPending(repoDir)
+
 	// Clear screen and render.
 	_, _ = fmt.Fprint(cmd.OutOrStdout(), "\033[2J\033[H")
-	_, _ = fmt.Fprint(cmd.OutOrStdout(), dashboard.Render(s))
+	data := &dashboard.DashboardData{
+		Summary:          s,
+		ActivityLog:      activityLines,
+		PendingApprovals: pendingMerges,
+	}
+	_, _ = fmt.Fprint(cmd.OutOrStdout(), dashboard.Render(data))
 }

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -75,7 +75,7 @@ func renderDashboard(cmd *cobra.Command) {
 
 	// Clear screen and render.
 	_, _ = fmt.Fprint(cmd.OutOrStdout(), "\033[2J\033[H")
-	data := &dashboard.DashboardData{
+	data := &dashboard.Data{
 		Summary:          s,
 		ActivityLog:      activityLines,
 		PendingApprovals: pendingMerges,

--- a/cmd/missioncontrol.go
+++ b/cmd/missioncontrol.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/drdanmaggs/rocket-fuel/internal/dashboard"
 	"github.com/drdanmaggs/rocket-fuel/internal/missioncontrol"
 	"github.com/drdanmaggs/rocket-fuel/internal/session"
 	"github.com/drdanmaggs/rocket-fuel/internal/tmux"
@@ -39,6 +40,11 @@ func runMissionControl(cmd *cobra.Command, _ []string) error {
 	interval, _ := cmd.Flags().GetDuration("interval")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 
+	repoDir, err := repoRoot()
+	if err != nil {
+		return err
+	}
+
 	fns := buildMissionControlFuncs(dryRun)
 
 	if !loop {
@@ -47,6 +53,7 @@ func runMissionControl(cmd *cobra.Command, _ []string) error {
 			return err
 		}
 		printCycleResult(cmd, result)
+		recordCycleActivity(repoDir, result)
 		return nil
 	}
 
@@ -68,7 +75,7 @@ func runMissionControl(cmd *cobra.Command, _ []string) error {
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), msg)
 	}
 
-	missioncontrol.Loop(ctx, interval, fns, logFn)
+	missioncontrol.LoopWithActivity(ctx, interval, fns, logFn, repoDir)
 
 	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Mission Control offline.")
 	return nil
@@ -179,5 +186,19 @@ func printCycleResult(cmd *cobra.Command, result *missioncontrol.CycleResult) {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "reap error: %v\n", result.ReapErr)
 	} else {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "reap: %s\n", result.ReapResult)
+	}
+}
+
+func recordCycleActivity(repoDir string, result *missioncontrol.CycleResult) {
+	if result.DispatchErr != nil {
+		_ = dashboard.WriteActivity(repoDir, fmt.Sprintf("dispatch error: %v", result.DispatchErr))
+	} else if result.DispatchResult != "" {
+		_ = dashboard.WriteActivity(repoDir, fmt.Sprintf("dispatch: %s", result.DispatchResult))
+	}
+
+	if result.ReapErr != nil {
+		_ = dashboard.WriteActivity(repoDir, fmt.Sprintf("reap error: %v", result.ReapErr))
+	} else if result.ReapResult != "" {
+		_ = dashboard.WriteActivity(repoDir, fmt.Sprintf("reap: %s", result.ReapResult))
 	}
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -1,14 +1,18 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/drdanmaggs/rocket-fuel/internal/launch"
 	"github.com/drdanmaggs/rocket-fuel/internal/project"
+	"github.com/drdanmaggs/rocket-fuel/internal/projects"
 	"github.com/drdanmaggs/rocket-fuel/internal/selfupdate"
 	"github.com/drdanmaggs/rocket-fuel/internal/session"
 	"github.com/drdanmaggs/rocket-fuel/internal/tmux"
@@ -37,7 +41,28 @@ func runUp(cmd *cobra.Command, _ []string) error {
 	// Pre-flight: must be in a git repo.
 	repoDir, err := repoRoot()
 	if err != nil {
-		return fmt.Errorf("not in a git repository — cd into your project first")
+		// Try to load from project registry.
+		reg, regErr := projects.LoadRegistry()
+		if regErr != nil || len(reg) == 0 {
+			return fmt.Errorf("not in a git repository — cd into your project first")
+		}
+
+		// Show available projects and prompt user to pick one.
+		selected, pickErr := pickProject(out, reg)
+		if pickErr != nil {
+			return fmt.Errorf("project selection failed: %w", pickErr)
+		}
+
+		// Change to the selected project directory.
+		if err := os.Chdir(selected.Path); err != nil {
+			return fmt.Errorf("could not cd into %s: %w", selected.Path, err)
+		}
+
+		// Now verify we're in a git repo.
+		repoDir, err = repoRoot()
+		if err != nil {
+			return fmt.Errorf("selected project is not a git repository: %w", err)
+		}
 	}
 
 	// Self-update: check if binary is stale, rebuild if needed.
@@ -84,6 +109,12 @@ func runUp(cmd *cobra.Command, _ []string) error {
 		_, _ = fmt.Fprintf(out, "  Reattaching to existing session\n\n")
 	}
 
+	// Remember this project for future launches.
+	repoName := filepath.Base(repoDir)
+	if err := projects.SaveProject(repoDir, repoName); err != nil {
+		_, _ = fmt.Fprintf(out, "  Warning: could not save project to registry: %v\n", err)
+	}
+
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	if dryRun {
 		_, _ = fmt.Fprintln(out, "Dry run — not attaching.")
@@ -96,6 +127,35 @@ func runUp(cmd *cobra.Command, _ []string) error {
 	}
 
 	return nil
+}
+
+// pickProject prompts the user to select a project from the registry.
+func pickProject(w io.Writer, registry []projects.Project) (*projects.Project, error) {
+	_, _ = fmt.Fprintln(w, "Rocket Fuel")
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, "  Recent projects:")
+	_, _ = fmt.Fprintln(w)
+
+	for i, p := range registry {
+		_, _ = fmt.Fprintf(w, "  %d) %s (%s)\n", i+1, p.Name, p.Path)
+	}
+
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprint(w, "  Select a project (number): ")
+
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, fmt.Errorf("failed to read input: %w", err)
+	}
+
+	input = strings.TrimSpace(input)
+	choice, err := strconv.Atoi(input)
+	if err != nil || choice < 1 || choice > len(registry) {
+		return nil, fmt.Errorf("invalid selection")
+	}
+
+	return &registry[choice-1], nil
 }
 
 func printLaunchBanner(w io.Writer) {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -67,6 +67,13 @@ func runUp(cmd *cobra.Command, _ []string) error {
 			_, _ = fmt.Fprintf(out, "  Warning: could not launch integrator: %v\n", err)
 		}
 
+		// Split the integrator window: dashboard on the right (30%).
+		if err := tm.SplitPane(sessionName, session.WindowIntegrator, "h", 30, "rf dashboard"); err != nil {
+			_, _ = fmt.Fprintf(out, "  Warning: could not create dashboard pane: %v\n", err)
+		}
+		// Refocus the left pane (integrator/Claude).
+		_ = tm.Run("select-pane", "-t", sessionName+":"+session.WindowIntegrator+".0")
+
 		// Launch mission control in its window.
 		if err := tm.SendKeys(sessionName, session.WindowMissionCtrl, "rf mission-control --loop"); err != nil {
 			_, _ = fmt.Fprintf(out, "  Warning: could not launch mission control: %v\n", err)

--- a/docs/plans/2026-03-21-split-pane-dashboard.md
+++ b/docs/plans/2026-03-21-split-pane-dashboard.md
@@ -1,0 +1,54 @@
+# TDD Plan: Split-pane dashboard
+
+## Context
+The Integrator gets blocked by permission prompts when merging PRs, stopping all work. A split-pane dashboard in the integrator tab solves this: Claude runs on the left, a live dashboard runs on the right showing status, activity feed, and pending approvals. The Visionary approves merges when ready without interrupting the Integrator.
+
+## Architecture
+tmux split-pane within the integrator window. Left pane: Claude Code (70%). Right pane: `rf dashboard` command (30%). The dashboard polls status every 10 seconds, tails an activity log, and reads a file-based approval queue. Mission control writes activity events. The Integrator queues merge requests instead of merging directly.
+
+## Session Constants
+Test command: `go test -race ./...`
+Test file pattern: colocated `*_test.go`
+Test helpers: `internal/testutil/` (tmux.go, git.go)
+
+## Slice 1: tmux SplitPane + session wiring
+Type: unit + integration | Status: pending
+Files: `internal/tmux/tmux.go`, `internal/session/session.go`, `internal/session/session_integration_test.go`, `cmd/up.go`
+
+- [ ] SplitPane creates a horizontal split in a tmux window
+- [ ] SplitPane runs a command in the new pane
+- [ ] session.Setup splits integrator window with `rf dashboard` in right pane (30%)
+- [ ] Integration test: split pane exists after Setup
+
+## Slice 2: `rf dashboard` — live status display
+Type: unit | Status: pending
+Files: `internal/dashboard/dashboard.go`, `internal/dashboard/dashboard_test.go`, `cmd/dashboard.go`
+Builds on: Slice 1
+
+- [ ] Render() formats worker status for narrow pane (~35 chars wide)
+- [ ] Render() shows session state (active/inactive)
+- [ ] Render() shows worker list with PR status
+- [ ] Dashboard refreshes on a 10-second ticker
+- [ ] Graceful handling when no workers exist
+
+## Slice 3: Activity feed from mission control
+Type: unit | Status: pending
+Files: `internal/dashboard/activity.go`, `internal/dashboard/activity_test.go`, `cmd/heartbeat.go`
+Builds on: Slice 2
+
+- [ ] Mission control writes timestamped events to .rocket-fuel/activity.log
+- [ ] Dashboard reads last 10 lines from activity log
+- [ ] Events include: dispatch, reap, nudge sent
+- [ ] Activity section renders below status in dashboard
+
+## Slice 4: Approval queue for pending merges
+Type: unit | Status: pending
+Files: `internal/dashboard/approvals.go`, `internal/dashboard/approvals_test.go`, `internal/prime/integrator.md`
+Builds on: Slice 3
+
+- [ ] AddPending writes merge request to .rocket-fuel/pending-merges.json
+- [ ] ListPending returns current queue
+- [ ] RemovePending removes approved item
+- [ ] Dashboard shows pending approvals at top of display
+- [ ] Integrator prompt updated: queue merges instead of merging directly
+- [ ] Integrator prompt: respond to "merge #N" by executing from queue

--- a/internal/dashboard/activity.go
+++ b/internal/dashboard/activity.go
@@ -23,7 +23,7 @@ func WriteActivity(repoDir, message string) error {
 	if err != nil {
 		return fmt.Errorf("open activity log: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	// Write timestamped line.
 	timestamp := time.Now().Format("2006-01-02 15:04:05")
@@ -47,7 +47,7 @@ func ReadActivity(repoDir string, lines int) []string {
 		}
 		return []string{}
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var allLines []string
 	scanner := bufio.NewScanner(f)

--- a/internal/dashboard/activity.go
+++ b/internal/dashboard/activity.go
@@ -1,0 +1,63 @@
+package dashboard
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// WriteActivity appends a timestamped line to the activity log.
+func WriteActivity(repoDir, message string) error {
+	logPath := filepath.Join(repoDir, ".rocket-fuel", "activity.log")
+
+	// Ensure the directory exists.
+	dir := filepath.Dir(logPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create directory: %w", err)
+	}
+
+	// Open file in append mode, creating if it doesn't exist.
+	f, err := os.OpenFile(logPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("open activity log: %w", err)
+	}
+	defer f.Close()
+
+	// Write timestamped line.
+	timestamp := time.Now().Format("2006-01-02 15:04:05")
+	line := fmt.Sprintf("[%s] %s\n", timestamp, message)
+	if _, err := f.WriteString(line); err != nil {
+		return fmt.Errorf("write activity log: %w", err)
+	}
+
+	return nil
+}
+
+// ReadActivity reads the last N lines from the activity log.
+// Returns an empty slice if the file doesn't exist.
+func ReadActivity(repoDir string, lines int) []string {
+	logPath := filepath.Join(repoDir, ".rocket-fuel", "activity.log")
+
+	f, err := os.Open(logPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []string{}
+		}
+		return []string{}
+	}
+	defer f.Close()
+
+	var allLines []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		allLines = append(allLines, scanner.Text())
+	}
+
+	// Return last N lines.
+	if len(allLines) <= lines {
+		return allLines
+	}
+	return allLines[len(allLines)-lines:]
+}

--- a/internal/dashboard/activity_test.go
+++ b/internal/dashboard/activity_test.go
@@ -1,0 +1,100 @@
+package dashboard
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteActivity_createsFileAndAppends(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	repoDir := tmpDir
+
+	// Write first line.
+	err := WriteActivity(repoDir, "test message 1")
+	if err != nil {
+		t.Fatalf("WriteActivity: %v", err)
+	}
+
+	// Verify file was created.
+	logPath := filepath.Join(repoDir, ".rocket-fuel", "activity.log")
+	if _, err := os.Stat(logPath); err != nil {
+		t.Fatalf("activity.log not created: %v", err)
+	}
+
+	// Write second line.
+	err = WriteActivity(repoDir, "test message 2")
+	if err != nil {
+		t.Fatalf("WriteActivity second: %v", err)
+	}
+
+	// Verify both lines are present.
+	content, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	text := string(content)
+	if !strings.Contains(text, "test message 1") {
+		t.Error("expected first message in log")
+	}
+	if !strings.Contains(text, "test message 2") {
+		t.Error("expected second message in log")
+	}
+	if strings.Index(text, "test message 1") > strings.Index(text, "test message 2") {
+		t.Error("messages out of order")
+	}
+}
+
+func TestReadActivity_returnsLastNLines(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	repoDir := tmpDir
+
+	// Write multiple lines.
+	for i := 1; i <= 5; i++ {
+		err := WriteActivity(repoDir, "message "+string(rune('0'+i)))
+		if err != nil {
+			t.Fatalf("WriteActivity: %v", err)
+		}
+	}
+
+	// Read last 3 lines.
+	lines := ReadActivity(repoDir, 3)
+
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(lines))
+	}
+
+	// Verify they're the last 3 lines.
+	if !strings.Contains(lines[0], "message 3") {
+		t.Error("expected message 3 in first line")
+	}
+	if !strings.Contains(lines[1], "message 4") {
+		t.Error("expected message 4 in second line")
+	}
+	if !strings.Contains(lines[2], "message 5") {
+		t.Error("expected message 5 in third line")
+	}
+}
+
+func TestReadActivity_fileNotExist(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	repoDir := tmpDir
+
+	// Try to read from non-existent file.
+	lines := ReadActivity(repoDir, 10)
+
+	if lines == nil {
+		t.Error("expected empty slice, got nil")
+	}
+	if len(lines) != 0 {
+		t.Errorf("expected empty slice, got %d lines", len(lines))
+	}
+}

--- a/internal/dashboard/approvals.go
+++ b/internal/dashboard/approvals.go
@@ -26,7 +26,7 @@ func AddPending(repoDir string, pm PendingMerge) error {
 	}
 
 	// Read existing entries.
-	var existing []PendingMerge
+	existing := make([]PendingMerge, 0, 1)
 	if data, err := os.ReadFile(filePath); err == nil {
 		if err := json.Unmarshal(data, &existing); err != nil {
 			return fmt.Errorf("parse pending merges: %w", err)

--- a/internal/dashboard/approvals.go
+++ b/internal/dashboard/approvals.go
@@ -1,0 +1,110 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// PendingMerge represents a PR awaiting approval.
+type PendingMerge struct {
+	PR        int    `json:"pr"`
+	Title     string `json:"title"`
+	Reason    string `json:"reason"`
+	Timestamp string `json:"timestamp"`
+}
+
+// AddPending appends a pending merge to the queue.
+func AddPending(repoDir string, pm PendingMerge) error {
+	filePath := filepath.Join(repoDir, ".rocket-fuel", "pending-merges.json")
+
+	// Ensure the directory exists.
+	dir := filepath.Dir(filePath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create directory: %w", err)
+	}
+
+	// Read existing entries.
+	var existing []PendingMerge
+	if data, err := os.ReadFile(filePath); err == nil {
+		if err := json.Unmarshal(data, &existing); err != nil {
+			return fmt.Errorf("parse pending merges: %w", err)
+		}
+	}
+
+	// Append new entry.
+	existing = append(existing, pm)
+
+	// Write back to file.
+	data, err := json.MarshalIndent(existing, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal pending merges: %w", err)
+	}
+
+	if err := os.WriteFile(filePath, data, 0o644); err != nil {
+		return fmt.Errorf("write pending merges: %w", err)
+	}
+
+	return nil
+}
+
+// ListPending returns all pending merges from the queue.
+// Returns an empty slice if the file doesn't exist.
+func ListPending(repoDir string) []PendingMerge {
+	filePath := filepath.Join(repoDir, ".rocket-fuel", "pending-merges.json")
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []PendingMerge{}
+		}
+		return []PendingMerge{}
+	}
+
+	var pending []PendingMerge
+	if err := json.Unmarshal(data, &pending); err != nil {
+		return []PendingMerge{}
+	}
+
+	return pending
+}
+
+// RemovePending removes a pending merge by PR number.
+func RemovePending(repoDir string, pr int) error {
+	filePath := filepath.Join(repoDir, ".rocket-fuel", "pending-merges.json")
+
+	// Read existing entries.
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read pending merges: %w", err)
+	}
+
+	var existing []PendingMerge
+	if err := json.Unmarshal(data, &existing); err != nil {
+		return fmt.Errorf("parse pending merges: %w", err)
+	}
+
+	// Remove the entry with the matching PR number.
+	var filtered []PendingMerge
+	for _, pm := range existing {
+		if pm.PR != pr {
+			filtered = append(filtered, pm)
+		}
+	}
+
+	// Write back to file.
+	output, err := json.MarshalIndent(filtered, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal pending merges: %w", err)
+	}
+
+	if err := os.WriteFile(filePath, output, 0o644); err != nil {
+		return fmt.Errorf("write pending merges: %w", err)
+	}
+
+	return nil
+}

--- a/internal/dashboard/approvals_test.go
+++ b/internal/dashboard/approvals_test.go
@@ -1,0 +1,128 @@
+package dashboard
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAddPending_createsFileAndAddsEntry(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	pm := PendingMerge{
+		PR:        42,
+		Title:     "Add feature X",
+		Reason:    "Review pending",
+		Timestamp: "2026-03-21T10:00:00Z",
+	}
+
+	if err := AddPending(tmpDir, pm); err != nil {
+		t.Fatalf("AddPending failed: %v", err)
+	}
+
+	// Verify file exists.
+	filePath := filepath.Join(tmpDir, ".rocket-fuel", "pending-merges.json")
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		t.Fatal("pending-merges.json was not created")
+	}
+
+	// Verify content.
+	pending := ListPending(tmpDir)
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 pending merge, got %d", len(pending))
+	}
+
+	if pending[0].PR != 42 {
+		t.Errorf("expected PR 42, got %d", pending[0].PR)
+	}
+	if pending[0].Title != "Add feature X" {
+		t.Errorf("expected title 'Add feature X', got '%s'", pending[0].Title)
+	}
+}
+
+func TestListPending_returnsEntries(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// Add multiple entries.
+	pm1 := PendingMerge{PR: 42, Title: "Feature A", Reason: "Needs review", Timestamp: "2026-03-21T10:00:00Z"}
+	pm2 := PendingMerge{PR: 43, Title: "Feature B", Reason: "Needs review", Timestamp: "2026-03-21T11:00:00Z"}
+
+	if err := AddPending(tmpDir, pm1); err != nil {
+		t.Fatalf("AddPending pm1 failed: %v", err)
+	}
+	if err := AddPending(tmpDir, pm2); err != nil {
+		t.Fatalf("AddPending pm2 failed: %v", err)
+	}
+
+	// List and verify.
+	pending := ListPending(tmpDir)
+	if len(pending) != 2 {
+		t.Fatalf("expected 2 pending merges, got %d", len(pending))
+	}
+
+	if pending[0].PR != 42 {
+		t.Errorf("expected first PR to be 42, got %d", pending[0].PR)
+	}
+	if pending[1].PR != 43 {
+		t.Errorf("expected second PR to be 43, got %d", pending[1].PR)
+	}
+}
+
+func TestRemovePending_removesSpecificEntry(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// Add multiple entries.
+	pm1 := PendingMerge{PR: 42, Title: "Feature A", Reason: "Needs review", Timestamp: "2026-03-21T10:00:00Z"}
+	pm2 := PendingMerge{PR: 43, Title: "Feature B", Reason: "Needs review", Timestamp: "2026-03-21T11:00:00Z"}
+	pm3 := PendingMerge{PR: 44, Title: "Feature C", Reason: "Needs review", Timestamp: "2026-03-21T12:00:00Z"}
+
+	if err := AddPending(tmpDir, pm1); err != nil {
+		t.Fatalf("AddPending pm1 failed: %v", err)
+	}
+	if err := AddPending(tmpDir, pm2); err != nil {
+		t.Fatalf("AddPending pm2 failed: %v", err)
+	}
+	if err := AddPending(tmpDir, pm3); err != nil {
+		t.Fatalf("AddPending pm3 failed: %v", err)
+	}
+
+	// Remove middle entry.
+	if err := RemovePending(tmpDir, 43); err != nil {
+		t.Fatalf("RemovePending failed: %v", err)
+	}
+
+	// Verify only 2 remain.
+	pending := ListPending(tmpDir)
+	if len(pending) != 2 {
+		t.Fatalf("expected 2 pending merges after removal, got %d", len(pending))
+	}
+
+	if pending[0].PR != 42 {
+		t.Errorf("expected first PR to be 42, got %d", pending[0].PR)
+	}
+	if pending[1].PR != 44 {
+		t.Errorf("expected second PR to be 44, got %d", pending[1].PR)
+	}
+}
+
+func TestListPending_returnsEmptySliceWhenFileNotExists(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// Don't create any file.
+	pending := ListPending(tmpDir)
+
+	if pending == nil {
+		t.Fatal("expected empty slice, got nil")
+	}
+	if len(pending) != 0 {
+		t.Fatalf("expected empty slice, got %d entries", len(pending))
+	}
+}

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -8,15 +8,22 @@ import (
 	"github.com/drdanmaggs/rocket-fuel/internal/status"
 )
 
+// DashboardData holds all data needed to render the dashboard.
+type DashboardData struct {
+	Summary          *status.Summary
+	ActivityLog      []string
+	PendingApprovals []PendingMerge
+}
+
 // Render formats the dashboard for a narrow pane (~35 chars).
-func Render(s *status.Summary) string {
+func Render(data *DashboardData) string {
 	var b strings.Builder
 
 	_, _ = fmt.Fprintln(&b, "━━━ DASHBOARD ━━━")
 	_, _ = fmt.Fprintln(&b)
 
 	// Session state.
-	if s.SessionActive {
+	if data.Summary.SessionActive {
 		_, _ = fmt.Fprintln(&b, "Session: ACTIVE")
 	} else {
 		_, _ = fmt.Fprintln(&b, "Session: INACTIVE")
@@ -24,11 +31,11 @@ func Render(s *status.Summary) string {
 	_, _ = fmt.Fprintln(&b)
 
 	// Workers.
-	if len(s.Workers) == 0 {
+	if len(data.Summary.Workers) == 0 {
 		_, _ = fmt.Fprintln(&b, "Workers: none")
 	} else {
-		_, _ = fmt.Fprintf(&b, "Workers: %d\n", len(s.Workers))
-		for _, w := range s.Workers {
+		_, _ = fmt.Fprintf(&b, "Workers: %d\n", len(data.Summary.Workers))
+		for _, w := range data.Summary.Workers {
 			icon := "  "
 			if w.WindowOpen {
 				icon = "▶ "
@@ -40,6 +47,28 @@ func Render(s *status.Summary) string {
 				pr = " [PR]"
 			}
 			_, _ = fmt.Fprintf(&b, " %s%s%s\n", icon, w.Name, pr)
+		}
+	}
+	_, _ = fmt.Fprintln(&b)
+
+	// Pending approvals.
+	_, _ = fmt.Fprintln(&b, "Pending Approval:")
+	if len(data.PendingApprovals) == 0 {
+		_, _ = fmt.Fprintln(&b, "  (none)")
+	} else {
+		for _, pm := range data.PendingApprovals {
+			_, _ = fmt.Fprintf(&b, "  #%d %s\n", pm.PR, pm.Reason)
+		}
+	}
+	_, _ = fmt.Fprintln(&b)
+
+	// Activity log.
+	_, _ = fmt.Fprintln(&b, "Activity:")
+	if len(data.ActivityLog) == 0 {
+		_, _ = fmt.Fprintln(&b, "  (none)")
+	} else {
+		for _, entry := range data.ActivityLog {
+			_, _ = fmt.Fprintf(&b, "  %s\n", entry)
 		}
 	}
 

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -1,0 +1,47 @@
+// Package dashboard provides a live-updating status display for the split pane.
+package dashboard
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/drdanmaggs/rocket-fuel/internal/status"
+)
+
+// Render formats the dashboard for a narrow pane (~35 chars).
+func Render(s *status.Summary) string {
+	var b strings.Builder
+
+	_, _ = fmt.Fprintln(&b, "━━━ DASHBOARD ━━━")
+	_, _ = fmt.Fprintln(&b)
+
+	// Session state.
+	if s.SessionActive {
+		_, _ = fmt.Fprintln(&b, "Session: ACTIVE")
+	} else {
+		_, _ = fmt.Fprintln(&b, "Session: INACTIVE")
+	}
+	_, _ = fmt.Fprintln(&b)
+
+	// Workers.
+	if len(s.Workers) == 0 {
+		_, _ = fmt.Fprintln(&b, "Workers: none")
+	} else {
+		_, _ = fmt.Fprintf(&b, "Workers: %d\n", len(s.Workers))
+		for _, w := range s.Workers {
+			icon := "  "
+			if w.WindowOpen {
+				icon = "▶ "
+			} else {
+				icon = "✓ "
+			}
+			pr := ""
+			if w.HasPR {
+				pr = " [PR]"
+			}
+			_, _ = fmt.Fprintf(&b, " %s%s%s\n", icon, w.Name, pr)
+		}
+	}
+
+	return b.String()
+}

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -8,15 +8,15 @@ import (
 	"github.com/drdanmaggs/rocket-fuel/internal/status"
 )
 
-// DashboardData holds all data needed to render the dashboard.
-type DashboardData struct {
+// Data holds all data needed to render the dashboard.
+type Data struct {
 	Summary          *status.Summary
 	ActivityLog      []string
 	PendingApprovals []PendingMerge
 }
 
 // Render formats the dashboard for a narrow pane (~35 chars).
-func Render(data *DashboardData) string {
+func Render(data *Data) string {
 	var b strings.Builder
 
 	_, _ = fmt.Fprintln(&b, "━━━ DASHBOARD ━━━")
@@ -36,11 +36,9 @@ func Render(data *DashboardData) string {
 	} else {
 		_, _ = fmt.Fprintf(&b, "Workers: %d\n", len(data.Summary.Workers))
 		for _, w := range data.Summary.Workers {
-			icon := "  "
+			icon := "✓ "
 			if w.WindowOpen {
 				icon = "▶ "
-			} else {
-				icon = "✓ "
 			}
 			pr := ""
 			if w.HasPR {

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -10,8 +10,10 @@ import (
 func TestRender_noWorkers(t *testing.T) {
 	t.Parallel()
 
-	s := &status.Summary{SessionActive: true}
-	out := Render(s)
+	data := &DashboardData{
+		Summary: &status.Summary{SessionActive: true},
+	}
+	out := Render(data)
 
 	if !strings.Contains(out, "DASHBOARD") {
 		t.Error("expected DASHBOARD header")
@@ -27,14 +29,16 @@ func TestRender_noWorkers(t *testing.T) {
 func TestRender_withWorkers(t *testing.T) {
 	t.Parallel()
 
-	s := &status.Summary{
-		SessionActive: true,
-		Workers: []status.WorkerStatus{
-			{Name: "worker-42", WindowOpen: true, HasPR: false},
-			{Name: "worker-43", WindowOpen: false, HasPR: true},
+	data := &DashboardData{
+		Summary: &status.Summary{
+			SessionActive: true,
+			Workers: []status.WorkerStatus{
+				{Name: "worker-42", WindowOpen: true, HasPR: false},
+				{Name: "worker-43", WindowOpen: false, HasPR: true},
+			},
 		},
 	}
-	out := Render(s)
+	out := Render(data)
 
 	if !strings.Contains(out, "Workers: 2") {
 		t.Error("expected worker count")

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -10,7 +10,7 @@ import (
 func TestRender_noWorkers(t *testing.T) {
 	t.Parallel()
 
-	data := &DashboardData{
+	data := &Data{
 		Summary: &status.Summary{SessionActive: true},
 	}
 	out := Render(data)
@@ -29,7 +29,7 @@ func TestRender_noWorkers(t *testing.T) {
 func TestRender_withWorkers(t *testing.T) {
 	t.Parallel()
 
-	data := &DashboardData{
+	data := &Data{
 		Summary: &status.Summary{
 			SessionActive: true,
 			Workers: []status.WorkerStatus{

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -1,0 +1,48 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/drdanmaggs/rocket-fuel/internal/status"
+)
+
+func TestRender_noWorkers(t *testing.T) {
+	t.Parallel()
+
+	s := &status.Summary{SessionActive: true}
+	out := Render(s)
+
+	if !strings.Contains(out, "DASHBOARD") {
+		t.Error("expected DASHBOARD header")
+	}
+	if !strings.Contains(out, "ACTIVE") {
+		t.Error("expected ACTIVE session")
+	}
+	if !strings.Contains(out, "none") {
+		t.Error("expected 'none' for no workers")
+	}
+}
+
+func TestRender_withWorkers(t *testing.T) {
+	t.Parallel()
+
+	s := &status.Summary{
+		SessionActive: true,
+		Workers: []status.WorkerStatus{
+			{Name: "worker-42", WindowOpen: true, HasPR: false},
+			{Name: "worker-43", WindowOpen: false, HasPR: true},
+		},
+	}
+	out := Render(s)
+
+	if !strings.Contains(out, "Workers: 2") {
+		t.Error("expected worker count")
+	}
+	if !strings.Contains(out, "worker-42") {
+		t.Error("expected worker-42")
+	}
+	if !strings.Contains(out, "[PR]") {
+		t.Error("expected PR indicator")
+	}
+}

--- a/internal/missioncontrol/heartbeat.go
+++ b/internal/missioncontrol/heartbeat.go
@@ -1,4 +1,4 @@
-// Package heartbeat provides the periodic dispatch + reap loop.
+// Package missioncontrol provides the periodic dispatch + reap loop.
 // The dumb, reliable background process — no AI, no decisions.
 package missioncontrol
 
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	"github.com/drdanmaggs/rocket-fuel/internal/dashboard"
 )
 
 // CycleFunc is a function that performs one operation and returns a summary string.
@@ -62,6 +64,25 @@ func Loop(ctx context.Context, interval time.Duration, fns Funcs, log func(strin
 	}
 }
 
+// LoopWithActivity runs dispatch + reap on a ticker until the context is cancelled,
+// and also writes events to the activity log.
+func LoopWithActivity(ctx context.Context, interval time.Duration, fns Funcs, log func(string), repoDir string) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	// Run immediately on start.
+	runAndLogWithActivity(fns, log, repoDir)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			runAndLogWithActivity(fns, log, repoDir)
+		}
+	}
+}
+
 func runAndLog(fns Funcs, log func(string)) {
 	result, _ := RunCycle(fns)
 
@@ -77,5 +98,31 @@ func runAndLog(fns Funcs, log func(string)) {
 		log(fmt.Sprintf("[%s] reap error: %v", ts, result.ReapErr))
 	} else if result.ReapResult != "" {
 		log(fmt.Sprintf("[%s] reap: %s", ts, result.ReapResult))
+	}
+}
+
+func runAndLogWithActivity(fns Funcs, log func(string), repoDir string) {
+	result, _ := RunCycle(fns)
+
+	ts := time.Now().Format("15:04:05")
+
+	if result.DispatchErr != nil {
+		msg := fmt.Sprintf("[%s] dispatch error: %v", ts, result.DispatchErr)
+		log(msg)
+		_ = dashboard.WriteActivity(repoDir, fmt.Sprintf("dispatch error: %v", result.DispatchErr))
+	} else if result.DispatchResult != "" {
+		msg := fmt.Sprintf("[%s] dispatch: %s", ts, result.DispatchResult)
+		log(msg)
+		_ = dashboard.WriteActivity(repoDir, fmt.Sprintf("dispatch: %s", result.DispatchResult))
+	}
+
+	if result.ReapErr != nil {
+		msg := fmt.Sprintf("[%s] reap error: %v", ts, result.ReapErr)
+		log(msg)
+		_ = dashboard.WriteActivity(repoDir, fmt.Sprintf("reap error: %v", result.ReapErr))
+	} else if result.ReapResult != "" {
+		msg := fmt.Sprintf("[%s] reap: %s", ts, result.ReapResult)
+		log(msg)
+		_ = dashboard.WriteActivity(repoDir, fmt.Sprintf("reap: %s", result.ReapResult))
 	}
 }

--- a/internal/projects/registry.go
+++ b/internal/projects/registry.go
@@ -1,0 +1,156 @@
+// Package projects provides a registry of recently used projects for quick access.
+package projects
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+// Project represents a single project entry in the registry.
+type Project struct {
+	Path     string    `json:"path"`
+	Name     string    `json:"name"`
+	LastUsed time.Time `json:"last_used"`
+}
+
+// registryPath returns the path to the global projects registry file.
+func registryPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	return filepath.Join(home, ".rocket-fuel", "projects.json"), nil
+}
+
+// loadRegistryFromPath reads projects from a specific registry file path.
+// Internal helper for testing.
+func loadRegistryFromPath(regPath string) ([]Project, error) {
+	data, err := os.ReadFile(regPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []Project{}, nil
+		}
+		return nil, fmt.Errorf("read registry: %w", err)
+	}
+
+	var projects []Project
+	if err := json.Unmarshal(data, &projects); err != nil {
+		return nil, fmt.Errorf("parse registry: %w", err)
+	}
+
+	// Sort by LastUsed (most recent first).
+	sort.Slice(projects, func(i, j int) bool {
+		return projects[i].LastUsed.After(projects[j].LastUsed)
+	})
+
+	return projects, nil
+}
+
+// LoadRegistry reads the projects registry from disk.
+// Returns projects sorted by LastUsed (most recent first).
+// Returns an empty slice if the file doesn't exist.
+func LoadRegistry() ([]Project, error) {
+	regPath, err := registryPath()
+	if err != nil {
+		return nil, err
+	}
+	return loadRegistryFromPath(regPath)
+}
+
+// SaveProject adds or updates a project in the registry with the current timestamp.
+func SaveProject(path, name string) error {
+	regPath, err := registryPath()
+	if err != nil {
+		return err
+	}
+
+	// Ensure directory exists.
+	if err := os.MkdirAll(filepath.Dir(regPath), 0o755); err != nil {
+		return fmt.Errorf("create registry directory: %w", err)
+	}
+
+	// Load existing projects.
+	projects, err := loadRegistryFromPath(regPath)
+	if err != nil {
+		return err
+	}
+
+	// Find and update or append new project.
+	now := time.Now()
+	found := false
+	for i, p := range projects {
+		if p.Path == path {
+			projects[i].LastUsed = now
+			projects[i].Name = name
+			found = true
+			break
+		}
+	}
+	if !found {
+		projects = append(projects, Project{
+			Path:     path,
+			Name:     name,
+			LastUsed: now,
+		})
+	}
+
+	// Sort by LastUsed before saving.
+	sort.Slice(projects, func(i, j int) bool {
+		return projects[i].LastUsed.After(projects[j].LastUsed)
+	})
+
+	// Write back to disk.
+	data, err := json.MarshalIndent(projects, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal registry: %w", err)
+	}
+
+	if err := os.WriteFile(regPath, data, 0o644); err != nil {
+		return fmt.Errorf("write registry: %w", err)
+	}
+
+	return nil
+}
+
+// RemoveProject removes a project from the registry by path.
+func RemoveProject(path string) error {
+	regPath, err := registryPath()
+	if err != nil {
+		return err
+	}
+
+	// Load existing projects.
+	projects, err := loadRegistryFromPath(regPath)
+	if err != nil {
+		return err
+	}
+
+	// Filter out the project to remove.
+	filtered := make([]Project, 0, len(projects))
+	for _, p := range projects {
+		if p.Path != path {
+			filtered = append(filtered, p)
+		}
+	}
+
+	// If nothing was removed, return early.
+	if len(filtered) == len(projects) {
+		return nil
+	}
+
+	// Write back to disk.
+	data, err := json.MarshalIndent(filtered, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal registry: %w", err)
+	}
+
+	if err := os.WriteFile(regPath, data, 0o644); err != nil {
+		return fmt.Errorf("write registry: %w", err)
+	}
+
+	return nil
+}

--- a/internal/projects/registry_test.go
+++ b/internal/projects/registry_test.go
@@ -1,0 +1,151 @@
+package projects
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSaveProjectCreatesRegistry(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	regPath := filepath.Join(tmpDir, "projects.json")
+
+	// Manually save a project using the registry path approach.
+	regDir := filepath.Dir(regPath)
+	if err := os.MkdirAll(regDir, 0o755); err != nil {
+		t.Fatalf("failed to create registry dir: %v", err)
+	}
+
+	projects := []Project{
+		{Path: "/home/user/my-project", Name: "my-project", LastUsed: time.Now()},
+	}
+	data, _ := json.MarshalIndent(projects, "", "  ")
+	if err := os.WriteFile(regPath, data, 0o644); err != nil {
+		t.Fatalf("failed to write registry: %v", err)
+	}
+
+	// Load and verify.
+	loaded, err := loadRegistryFromPath(regPath)
+	if err != nil {
+		t.Fatalf("loadRegistryFromPath failed: %v", err)
+	}
+
+	if len(loaded) != 1 {
+		t.Errorf("expected 1 project, got %d", len(loaded))
+	}
+	if loaded[0].Path != "/home/user/my-project" {
+		t.Errorf("expected path /home/user/my-project, got %s", loaded[0].Path)
+	}
+	if loaded[0].Name != "my-project" {
+		t.Errorf("expected name my-project, got %s", loaded[0].Name)
+	}
+}
+
+func TestSaveProjectUpdatesExistingLastUsed(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	regPath := filepath.Join(tmpDir, "projects.json")
+
+	// Create registry directory and initial project.
+	regDir := filepath.Dir(regPath)
+	if err := os.MkdirAll(regDir, 0o755); err != nil {
+		t.Fatalf("failed to create registry dir: %v", err)
+	}
+
+	oldTime := time.Now().Add(-1 * time.Hour)
+	oldProjects := []Project{
+		{Path: "/home/user/my-project", Name: "my-project", LastUsed: oldTime},
+	}
+	data, _ := json.MarshalIndent(oldProjects, "", "  ")
+	if err := os.WriteFile(regPath, data, 0o644); err != nil {
+		t.Fatalf("failed to write initial registry: %v", err)
+	}
+
+	// Simulate saving the same project.
+	newProjects := []Project{
+		{Path: "/home/user/my-project", Name: "my-project", LastUsed: time.Now()},
+	}
+	data, _ = json.MarshalIndent(newProjects, "", "  ")
+	if err := os.WriteFile(regPath, data, 0o644); err != nil {
+		t.Fatalf("failed to update registry: %v", err)
+	}
+
+	// Verify LastUsed was updated.
+	projects, err := loadRegistryFromPath(regPath)
+	if err != nil {
+		t.Fatalf("loadRegistryFromPath failed: %v", err)
+	}
+
+	if len(projects) != 1 {
+		t.Errorf("expected 1 project, got %d", len(projects))
+	}
+	if projects[0].LastUsed.Before(oldTime.Add(time.Second)) {
+		t.Errorf("expected LastUsed to be updated")
+	}
+}
+
+func TestLoadRegistrySortedByLastUsed(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	regPath := filepath.Join(tmpDir, "projects.json")
+
+	// Create registry directory with projects in unsorted order.
+	regDir := filepath.Dir(regPath)
+	if err := os.MkdirAll(regDir, 0o755); err != nil {
+		t.Fatalf("failed to create registry dir: %v", err)
+	}
+
+	now := time.Now()
+	projects := []Project{
+		{Path: "/home/user/project1", Name: "project1", LastUsed: now.Add(-3 * time.Hour)},
+		{Path: "/home/user/project2", Name: "project2", LastUsed: now},
+		{Path: "/home/user/project3", Name: "project3", LastUsed: now.Add(-1 * time.Hour)},
+	}
+	data, _ := json.MarshalIndent(projects, "", "  ")
+	if err := os.WriteFile(regPath, data, 0o644); err != nil {
+		t.Fatalf("failed to write initial registry: %v", err)
+	}
+
+	// Load and verify sorting.
+	loaded, err := loadRegistryFromPath(regPath)
+	if err != nil {
+		t.Fatalf("loadRegistryFromPath failed: %v", err)
+	}
+
+	if len(loaded) != 3 {
+		t.Errorf("expected 3 projects, got %d", len(loaded))
+	}
+
+	// Most recent should be first.
+	if loaded[0].Name != "project2" {
+		t.Errorf("expected first project to be project2, got %s", loaded[0].Name)
+	}
+	if loaded[1].Name != "project3" {
+		t.Errorf("expected second project to be project3, got %s", loaded[1].Name)
+	}
+	if loaded[2].Name != "project1" {
+		t.Errorf("expected third project to be project1, got %s", loaded[2].Name)
+	}
+}
+
+func TestLoadRegistryReturnsEmptyWhenFileDoesNotExist(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	regPath := filepath.Join(tmpDir, "nonexistent", "projects.json")
+
+	projects, err := loadRegistryFromPath(regPath)
+	if err != nil {
+		t.Fatalf("loadRegistryFromPath failed: %v", err)
+	}
+
+	if len(projects) != 0 {
+		t.Errorf("expected empty slice, got %d projects", len(projects))
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -100,6 +100,32 @@ func (c *CLI) AttachCC(session string) error {
 	return syscall.Exec(tmuxPath, args, os.Environ())
 }
 
+// Run executes an arbitrary tmux command against the socket.
+func (c *CLI) Run(args ...string) error {
+	return c.run(args...)
+}
+
+// SplitPane splits a window horizontally (side by side) or vertically (top/bottom).
+// The new pane runs the given command. Percent is the size of the new pane.
+func (c *CLI) SplitPane(session, window, direction string, percent int, command string) error {
+	target := session + ":" + window
+	dirFlag := "-h" // horizontal = side by side
+	if direction == "v" || direction == "vertical" {
+		dirFlag = "-v"
+	}
+
+	args := []string{
+		"split-window", dirFlag,
+		"-t", target,
+		"-p", fmt.Sprintf("%d", percent),
+	}
+	if command != "" {
+		args = append(args, command)
+	}
+
+	return c.run(args...)
+}
+
 // ListSessions returns the names of all tmux sessions.
 func (c *CLI) ListSessions() []string {
 	out, err := c.output("list-sessions", "-F", "#{session_name}")


### PR DESCRIPTION
## Summary
- Integrator tab split: Claude left (70%), live dashboard right (30%)
- New tmux SplitPane + Run methods
- New rf dashboard command with 10-second refresh
- Shows workers, PRs, session state in narrow pane

Closes #128, #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)