### PR TITLE
refactor: expand tmux.Runner interface to eliminate type assertions

### DIFF
--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -10,13 +10,17 @@ type mockRunner struct {
 	selectErr      error
 }
 
-func (m *mockRunner) HasSession(_ string) bool      { return true }
-func (m *mockRunner) HasWindow(_, _ string) bool    { return true }
-func (m *mockRunner) NewSession(_ string) error     { return nil }
-func (m *mockRunner) NewWindow(_, _ string) error   { return nil }
-func (m *mockRunner) KillSession(_ string) error    { return nil }
-func (m *mockRunner) AttachCC(_ string) error       { return nil }
-func (m *mockRunner) SendKeys(_, _, _ string) error { return nil }
+func (m *mockRunner) HasSession(_ string) bool                        { return true }
+func (m *mockRunner) HasWindow(_, _ string) bool                      { return true }
+func (m *mockRunner) NewSession(_ string) error                       { return nil }
+func (m *mockRunner) NewWindow(_, _ string) error                     { return nil }
+func (m *mockRunner) KillSession(_ string) error                      { return nil }
+func (m *mockRunner) AttachCC(_ string) error                         { return nil }
+func (m *mockRunner) SendKeys(_, _, _ string) error                   { return nil }
+func (m *mockRunner) ListWindowNames(_ string) ([]string, error)      { return nil, nil }
+func (m *mockRunner) RenameWindow(_, _, _ string) error               { return nil }
+func (m *mockRunner) SplitPane(_, _, _ string, _ int, _ string) error { return nil }
+func (m *mockRunner) Run(_ ...string) error                           { return nil }
 
 func (m *mockRunner) SelectWindow(_, window string) error {
 	if m.selectErr != nil {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -31,9 +31,7 @@ func Setup(tm tmux.Runner, sessionName string) (bool, error) {
 	}
 
 	// Rename the default window (window 0) to "integrator".
-	if cli, ok := tm.(*tmux.CLI); ok {
-		_ = cli.RenameWindow(sessionName, "0", WindowIntegrator)
-	}
+	_ = tm.RenameWindow(sessionName, "0", WindowIntegrator)
 
 	// Create mission-control window.
 	if err := tm.NewWindow(sessionName, WindowMissionCtrl); err != nil {
@@ -63,18 +61,13 @@ func TeardownAll(tm tmux.Runner, sessionName string) (bool, error) {
 
 // ListWorkerWindows returns the names of worker windows in the session.
 func ListWorkerWindows(tm tmux.Runner, sessionName string) []string {
-	cli, ok := tm.(*tmux.CLI)
-	if !ok {
-		return nil
-	}
-
-	out, err := cli.ListWindowNames(sessionName)
+	names, err := tm.ListWindowNames(sessionName)
 	if err != nil {
 		return nil
 	}
 
 	var workers []string
-	for _, name := range out {
+	for _, name := range names {
 		// Worker windows are named "#N: title" (new) or "worker-N" (legacy).
 		if strings.HasPrefix(name, "#") || strings.HasPrefix(name, "worker-") {
 			workers = append(workers, name)

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -76,6 +76,23 @@ func (m *mockRunner) SendKeys(session, window, keys string) error {
 	return nil
 }
 
+func (m *mockRunner) ListWindowNames(session string) ([]string, error) {
+	m.calls = append(m.calls, "ListWindowNames:"+session)
+	return m.windows[session], nil
+}
+
+func (m *mockRunner) RenameWindow(session, target, newName string) error {
+	m.calls = append(m.calls, "RenameWindow:"+session+":"+target+":"+newName)
+	return nil
+}
+
+func (m *mockRunner) SplitPane(session, window, direction string, _ int, _ string) error {
+	m.calls = append(m.calls, "SplitPane:"+session+":"+window+":"+direction)
+	return nil
+}
+
+func (m *mockRunner) Run(_ ...string) error { return nil }
+
 var errMock = &mockError{}
 
 type mockError struct{}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -112,11 +112,7 @@ func Format(s *Summary) string {
 }
 
 func hasWindowWithPrefix(tm tmux.Runner, session, prefix string) bool {
-	cli, ok := tm.(*tmux.CLI)
-	if !ok {
-		return false
-	}
-	names, err := cli.ListWindowNames(session)
+	names, err := tm.ListWindowNames(session)
 	if err != nil {
 		return false
 	}

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -38,6 +38,21 @@ func (m *mockRunner) SelectWindow(session, window string) error {
 	return &mockErr{}
 }
 
+func (m *mockRunner) ListWindowNames(session string) ([]string, error) {
+	if m.windows[session] == nil {
+		return nil, nil
+	}
+	var names []string
+	for name := range m.windows[session] {
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+func (m *mockRunner) RenameWindow(_, _, _ string) error               { return nil }
+func (m *mockRunner) SplitPane(_, _, _ string, _ int, _ string) error { return nil }
+func (m *mockRunner) Run(_ ...string) error                           { return nil }
+
 type mockErr struct{}
 
 func (e *mockErr) Error() string { return "not found" }

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -21,6 +21,10 @@ type Runner interface {
 	KillSession(name string) error
 	AttachCC(session string) error
 	SendKeys(session, window, keys string) error
+	ListWindowNames(session string) ([]string, error)
+	RenameWindow(session, target, newName string) error
+	SplitPane(session, window, direction string, percent int, command string) error
+	Run(args ...string) error
 }
 
 // CLI implements Runner by calling the real tmux binary.

--- a/internal/worker/reap.go
+++ b/internal/worker/reap.go
@@ -100,13 +100,7 @@ func Reap(tm tmux.Runner, sessionName, repoDir string, dryRun ...bool) ([]ReapRe
 
 // hasWorkerWindow checks if any window in the session starts with the given prefix.
 func hasWorkerWindow(tm tmux.Runner, session, prefix string) bool {
-	cli, ok := tm.(*tmux.CLI)
-	if !ok {
-		// For mocks, fall back to HasWindow with the prefix.
-		return tm.HasWindow(session, prefix)
-	}
-
-	names, err := cli.ListWindowNames(session)
+	names, err := tm.ListWindowNames(session)
 	if err != nil {
 		return false
 	}

--- a/internal/worker/reap_test.go
+++ b/internal/worker/reap_test.go
@@ -72,6 +72,21 @@ func (m *mockTmuxRunner) KillSession(name string) error {
 func (m *mockTmuxRunner) AttachCC(_ string) error       { return nil }
 func (m *mockTmuxRunner) SendKeys(_, _, _ string) error { return nil }
 
+func (m *mockTmuxRunner) ListWindowNames(session string) ([]string, error) {
+	if m.windows[session] == nil {
+		return nil, nil
+	}
+	var names []string
+	for name := range m.windows[session] {
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+func (m *mockTmuxRunner) RenameWindow(_, _, _ string) error               { return nil }
+func (m *mockTmuxRunner) SplitPane(_, _, _ string, _ int, _ string) error { return nil }
+func (m *mockTmuxRunner) Run(_ ...string) error                           { return nil }
+
 type mockSelectError struct{}
 
 func (e *mockSelectError) Error() string { return "window not found" }


### PR DESCRIPTION
## Summary
- Added `ListWindowNames`, `RenameWindow`, `SplitPane`, and `Run` to the `tmux.Runner` interface
- Removed `*tmux.CLI` type assertions from `session`, `status`, and `worker/reap` packages
- Updated all 4 mock runners (session, worker, status, notify) to implement the new interface

## Test plan
- [x] All existing tests pass (mock runners updated)
- [x] Lint passes (zero issues)
- [x] No production behavior changes — mocks now get full coverage instead of silent degradation

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)