### PR TITLE
fix: add timeouts to all external commands to prevent hangs

### DIFF
--- a/cmd/missioncontrol.go
+++ b/cmd/missioncontrol.go
@@ -156,7 +156,10 @@ func buildReapNudge(r worker.ReapResult) string {
 
 // checkPRForBranch checks if a PR exists for the given branch.
 func checkPRForBranch(branch string) string {
-	out, err := exec.CommandContext(context.Background(),
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx,
 		"gh", "pr", "list", "--head", branch, "--json", "number,title,url", "--limit", "1",
 	).Output()
 	if err != nil {

--- a/cmd/prime.go
+++ b/cmd/prime.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/drdanmaggs/rocket-fuel/internal/prime"
 	"github.com/drdanmaggs/rocket-fuel/internal/project"
@@ -67,7 +68,10 @@ func runPrime(cmd *cobra.Command, _ []string) error {
 }
 
 func primeCurrentBranch() string {
-	out, err := exec.CommandContext(context.Background(), "git", "branch", "--show-current").Output()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "git", "branch", "--show-current").Output()
 	if err != nil {
 		return ""
 	}

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/drdanmaggs/rocket-fuel/internal/project"
 	"github.com/spf13/cobra"
@@ -171,7 +172,10 @@ func discoverAndSaveProject() (*project.Config, error) {
 }
 
 func repoOwnerAndName() (string, string, error) {
-	out, err := exec.CommandContext(context.Background(),
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx,
 		"gh", "repo", "view", "--json", "owner,name",
 	).Output()
 	if err != nil {

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/drdanmaggs/rocket-fuel/internal/session"
 	"github.com/drdanmaggs/rocket-fuel/internal/tmux"
@@ -106,7 +107,10 @@ type ghLabel struct {
 }
 
 func fetchIssue(number int) (*worker.Issue, error) {
-	out, err := exec.CommandContext(context.Background(), "gh", "issue", "view", strconv.Itoa(number), "--json", "number,title,body,labels").Output()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "gh", "issue", "view", strconv.Itoa(number), "--json", "number,title,body,labels").Output()
 	if err != nil {
 		return nil, fmt.Errorf("gh issue view: %w", err)
 	}

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -7,7 +7,11 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 )
+
+// cmdTimeout is the maximum time for git/go commands during self-update.
+const cmdTimeout = 60 * time.Second
 
 // Result describes what happened during an update check.
 type Result struct {
@@ -63,7 +67,10 @@ func Check(sourceDir, currentVersion, binaryPath string) (*Result, error) {
 }
 
 func gitOutput(dir string, args ...string) (string, error) {
-	cmd := exec.CommandContext(context.Background(), "git", args...)
+	ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	if err != nil {
@@ -73,13 +80,19 @@ func gitOutput(dir string, args ...string) (string, error) {
 }
 
 func gitRun(dir string, args ...string) error {
-	cmd := exec.CommandContext(context.Background(), "git", args...)
+	ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
 	return cmd.Run()
 }
 
 func goBuild(sourceDir, binaryPath string) error {
-	cmd := exec.CommandContext(context.Background(),
+	ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx,
 		"go", "build",
 		"-ldflags", fmt.Sprintf("-s -w -X github.com/drdanmaggs/rocket-fuel/cmd.Version=%s -X github.com/drdanmaggs/rocket-fuel/cmd.SourceDir=%s", shortHead(sourceDir), sourceDir),
 		"-o", binaryPath,


### PR DESCRIPTION
## Summary
- Added `context.WithTimeout` (30s for git/gh, 60s for go build) to every `exec.CommandContext` call
- Covers: worker spawn, reap, status, selfupdate, cmd layer (repoRoot, fetchIssue, ghRunner, checkPRForBranch, repoOwnerAndName, primeCurrentBranch)
- Prevents indefinite process hangs on network issues or unresponsive git repos

## Test plan
- [x] All existing tests pass (no behavior change for normal operations)
- [x] Lint clean
- [x] Build succeeds

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)