### PR TITLE
feat: Auto-discover repos when project registry is empty

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -44,7 +44,15 @@ func runUp(cmd *cobra.Command, _ []string) error {
 		// Try to load from project registry.
 		reg, regErr := projects.LoadRegistry()
 		if regErr != nil || len(reg) == 0 {
-			return fmt.Errorf("not in a git repository — cd into your project first")
+			// Registry empty — discover repos automatically.
+			homeDir, homeErr := os.UserHomeDir()
+			if homeErr != nil {
+				return fmt.Errorf("not in a git repository — cd into your project first")
+			}
+			reg = projects.DiscoverProjects(homeDir)
+			if len(reg) == 0 {
+				return fmt.Errorf("no git repositories found — cd into your project and run rf launch")
+			}
 		}
 
 		// Show available projects and prompt user to pick one.

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -59,6 +59,21 @@ func TeardownAll(tm tmux.Runner, sessionName string) (bool, error) {
 	return true, nil
 }
 
+// HasWindowWithPrefix checks if any window in the session has a name starting with prefix.
+// Shared by worker/reap and status to match "#N:" style worker window names.
+func HasWindowWithPrefix(tm tmux.Runner, sessionName, prefix string) bool {
+	names, err := tm.ListWindowNames(sessionName)
+	if err != nil {
+		return false
+	}
+	for _, name := range names {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // ListWorkerWindows returns the names of worker windows in the session.
 func ListWorkerWindows(tm tmux.Runner, sessionName string) []string {
 	names, err := tm.ListWindowNames(sessionName)

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -148,6 +148,33 @@ func TestSetupIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestHasWindowWithPrefixMatchesWorkerNames(t *testing.T) {
+	t.Parallel()
+
+	tm := newMockRunner()
+	tm.sessions["test"] = true
+	tm.windows["test"] = []string{"integrator", "#42: fix bug", "mission-control"}
+
+	if !HasWindowWithPrefix(tm, "test", "#42:") {
+		t.Error("expected HasWindowWithPrefix to find '#42:' prefix")
+	}
+
+	if HasWindowWithPrefix(tm, "test", "#99:") {
+		t.Error("expected HasWindowWithPrefix to NOT find '#99:' prefix")
+	}
+}
+
+func TestHasWindowWithPrefixNoWindows(t *testing.T) {
+	t.Parallel()
+
+	tm := newMockRunner()
+	tm.sessions["empty"] = true
+
+	if HasWindowWithPrefix(tm, "empty", "#42:") {
+		t.Error("expected false when no windows exist")
+	}
+}
+
 func TestSetupCleansUpOnSessionFailure(t *testing.T) {
 	t.Parallel()
 

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/drdanmaggs/rocket-fuel/internal/session"
 	"github.com/drdanmaggs/rocket-fuel/internal/tmux"
 )
 
@@ -56,7 +57,7 @@ func Gather(tm tmux.Runner, sessionName, repoDir string) (*Summary, error) {
 		// from worktree dir name (worker-N) to match.
 		issueNum := strings.TrimPrefix(name, "worker-")
 		windowPrefix := "#" + issueNum + ":"
-		windowOpen := s.SessionActive && (tm.HasWindow(sessionName, name) || hasWindowWithPrefix(tm, sessionName, windowPrefix))
+		windowOpen := s.SessionActive && (tm.HasWindow(sessionName, name) || session.HasWindowWithPrefix(tm, sessionName, windowPrefix))
 
 		ws := WorkerStatus{
 			Name:       name,
@@ -109,19 +110,6 @@ func Format(s *Summary) string {
 	}
 
 	return b.String()
-}
-
-func hasWindowWithPrefix(tm tmux.Runner, session, prefix string) bool {
-	names, err := tm.ListWindowNames(session)
-	if err != nil {
-		return false
-	}
-	for _, name := range names {
-		if strings.HasPrefix(name, prefix) {
-			return true
-		}
-	}
-	return false
 }
 
 func worktreeBranch(dir string) string {

--- a/internal/worker/reap.go
+++ b/internal/worker/reap.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/drdanmaggs/rocket-fuel/internal/session"
 	"github.com/drdanmaggs/rocket-fuel/internal/tmux"
 )
 
@@ -50,7 +51,7 @@ func Reap(tm tmux.Runner, sessionName, repoDir string, dryRun ...bool) ([]ReapRe
 		// format, so match by issue number prefix.
 		issueNum := strings.TrimPrefix(name, "worker-")
 		windowPrefix := "#" + issueNum + ":"
-		windowExists := tm.HasSession(sessionName) && hasWorkerWindow(tm, sessionName, windowPrefix)
+		windowExists := tm.HasSession(sessionName) && session.HasWindowWithPrefix(tm, sessionName, windowPrefix)
 
 		if windowExists {
 			results = append(results, ReapResult{
@@ -96,20 +97,6 @@ func Reap(tm tmux.Runner, sessionName, repoDir string, dryRun ...bool) ([]ReapRe
 	}
 
 	return results, nil
-}
-
-// hasWorkerWindow checks if any window in the session starts with the given prefix.
-func hasWorkerWindow(tm tmux.Runner, session, prefix string) bool {
-	names, err := tm.ListWindowNames(session)
-	if err != nil {
-		return false
-	}
-	for _, name := range names {
-		if strings.HasPrefix(name, prefix) {
-			return true
-		}
-	}
-	return false
 }
 
 func removeWorktree(repoDir, worktreeDir string) error {


### PR DESCRIPTION
## Summary
- When rf launch runs outside a repo with empty registry, scans ~/ for git repos
- Shows picker sorted by modification time
- Better error: "no git repositories found" when nothing discovered
- Supersedes #148

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)