### PR TITLE
feat: warn when project board exceeds 200 item limit

### DIFF
--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -27,6 +27,8 @@ type Item struct {
 type BoardSummary struct {
 	ProjectTitle string
 	Columns      map[string][]Item
+	Truncated    bool
+	TotalCount   int
 }
 
 // FetchBoard reads the current state of a GitHub Project board.
@@ -60,6 +62,8 @@ func FetchBoard(run GHRunner, owner string, projectNumber int) (*BoardSummary, e
 	summary := &BoardSummary{
 		ProjectTitle: fetchProjectTitle(run, owner, projectNumber),
 		Columns:      make(map[string][]Item),
+		TotalCount:   raw.TotalCount,
+		Truncated:    raw.TotalCount > len(raw.Items),
 	}
 
 	for _, item := range raw.Items {
@@ -110,6 +114,10 @@ func FormatBoard(board *BoardSummary) string {
 
 	_, _ = fmt.Fprintln(&b, "=== Project Board ===")
 	_, _ = fmt.Fprintln(&b)
+
+	if board.Truncated {
+		_, _ = fmt.Fprintf(&b, "WARNING: Board has %d items but only 200 are shown. Some items are hidden.\n\n", board.TotalCount)
+	}
 
 	for _, col := range columnOrder {
 		// Collect items from all board columns that match this canonical name (case-insensitive).

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -145,6 +145,106 @@ func TestFormatBoardNormalizesColumnCasing(t *testing.T) {
 	}
 }
 
+func TestFetchBoardSetsTruncatedWhenTotalCountExceedsItems(t *testing.T) {
+	t.Parallel()
+
+	fakeRun := func(args ...string) ([]byte, error) {
+		// item-list returns 2 items but totalCount says 250
+		if args[0] == "project" && args[1] == "item-list" {
+			return []byte(`{
+				"items": [
+					{"id":"1","title":"Issue A","status":"Backlog","content":{"number":1,"labels":[]}},
+					{"id":"2","title":"Issue B","status":"Backlog","content":{"number":2,"labels":[]}}
+				],
+				"totalCount": 250
+			}`), nil
+		}
+		// project view for title
+		if args[0] == "project" && args[1] == "view" {
+			return []byte(`{"title":"Test Project"}`), nil
+		}
+		return nil, nil
+	}
+
+	board, err := FetchBoard(fakeRun, "testowner", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !board.Truncated {
+		t.Error("expected Truncated to be true when totalCount > len(items)")
+	}
+	if board.TotalCount != 250 {
+		t.Errorf("expected TotalCount=250, got %d", board.TotalCount)
+	}
+}
+
+func TestFetchBoardNotTruncatedWhenAllItemsFit(t *testing.T) {
+	t.Parallel()
+
+	fakeRun := func(args ...string) ([]byte, error) {
+		if args[0] == "project" && args[1] == "item-list" {
+			return []byte(`{
+				"items": [
+					{"id":"1","title":"Issue A","status":"Backlog","content":{"number":1,"labels":[]}}
+				],
+				"totalCount": 1
+			}`), nil
+		}
+		if args[0] == "project" && args[1] == "view" {
+			return []byte(`{"title":"Test Project"}`), nil
+		}
+		return nil, nil
+	}
+
+	board, err := FetchBoard(fakeRun, "testowner", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if board.Truncated {
+		t.Error("expected Truncated to be false when totalCount == len(items)")
+	}
+	if board.TotalCount != 1 {
+		t.Errorf("expected TotalCount=1, got %d", board.TotalCount)
+	}
+}
+
+func TestFormatBoardShowsTruncationWarning(t *testing.T) {
+	t.Parallel()
+
+	board := &BoardSummary{
+		Columns:    map[string][]Item{},
+		Truncated:  true,
+		TotalCount: 250,
+	}
+
+	out := FormatBoard(board)
+
+	if !strings.Contains(out, "WARNING") {
+		t.Errorf("expected truncation warning in output\n\nGot:\n%s", out)
+	}
+	if !strings.Contains(out, "250") {
+		t.Errorf("expected total count in warning\n\nGot:\n%s", out)
+	}
+}
+
+func TestFormatBoardNoWarningWhenNotTruncated(t *testing.T) {
+	t.Parallel()
+
+	board := &BoardSummary{
+		Columns:    map[string][]Item{},
+		Truncated:  false,
+		TotalCount: 5,
+	}
+
+	out := FormatBoard(board)
+
+	if strings.Contains(out, "WARNING") {
+		t.Errorf("expected no truncation warning\n\nGot:\n%s", out)
+	}
+}
+
 func TestIsStandardColumnCaseInsensitive(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Add `Truncated` and `TotalCount` fields to `BoardSummary` struct
- `FetchBoard` now detects when `totalCount > len(items)` and sets the truncation flag
- `FormatBoard` displays a WARNING line when the board is truncated, showing the true total count
- Prevents silent data loss when a project board exceeds the 200-item query limit

Closes #139

## Test plan
- [x] Test that `FetchBoard` sets `Truncated=true` and `TotalCount` when totalCount exceeds item count
- [x] Test that `FetchBoard` sets `Truncated=false` when all items fit within the limit
- [x] Test that `FormatBoard` includes a WARNING with total count when truncated
- [x] Test that `FormatBoard` omits the warning when not truncated
- [x] Full test suite passes, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)