### PR TITLE
refactor: replace variadic bool in Reap with ReapConfig

### DIFF
--- a/cmd/missioncontrol.go
+++ b/cmd/missioncontrol.go
@@ -103,7 +103,7 @@ func buildMissionControlFuncs(dryRun bool) missioncontrol.Funcs {
 		tm := tmux.New()
 		sessionName := session.DefaultSessionName
 
-		results, err := worker.Reap(tm, sessionName, repoDir)
+		results, err := worker.Reap(tm, sessionName, repoDir, worker.ReapConfig{})
 		if err != nil {
 			return "", err
 		}

--- a/cmd/reap.go
+++ b/cmd/reap.go
@@ -32,7 +32,7 @@ func runReap(cmd *cobra.Command, _ []string) error {
 	tm := tmux.New()
 	sessionName := session.DefaultSessionName
 
-	results, err := worker.Reap(tm, sessionName, repoDir, dryRun)
+	results, err := worker.Reap(tm, sessionName, repoDir, worker.ReapConfig{DryRun: dryRun})
 	if err != nil {
 		return fmt.Errorf("reap failed: %w", err)
 	}

--- a/internal/worker/reap.go
+++ b/internal/worker/reap.go
@@ -19,13 +19,17 @@ type ReapResult struct {
 	Reason      string
 }
 
+// ReapConfig controls the behaviour of the Reap function.
+type ReapConfig struct {
+	DryRun bool
+}
+
 // Reap finds completed workers and cleans up their worktrees and tmux windows.
 // A worker is considered complete when its tmux window no longer exists
 // in the main session (Claude Code session ended).
-// If dryRun is true, reports what would be reaped without deleting.
-func Reap(tm tmux.Runner, sessionName, repoDir string, dryRun ...bool) ([]ReapResult, error) {
-	isDryRun := len(dryRun) > 0 && dryRun[0]
-	_ = isDryRun // used below
+// If cfg.DryRun is true, reports what would be reaped without deleting.
+func Reap(tm tmux.Runner, sessionName, repoDir string, cfg ReapConfig) ([]ReapResult, error) {
+	isDryRun := cfg.DryRun
 	worktreesDir := filepath.Join(repoDir, ".worktrees")
 
 	entries, err := os.ReadDir(worktreesDir)

--- a/internal/worker/reap_test.go
+++ b/internal/worker/reap_test.go
@@ -105,7 +105,7 @@ func TestReapCleansUpCompletedWorkers(t *testing.T) {
 	tm := newMockTmuxRunner()
 	tm.sessions["rf-integrator"] = true
 
-	results, err := Reap(tm, "rf-integrator", repoDir)
+	results, err := Reap(tm, "rf-integrator", repoDir, ReapConfig{})
 	if err != nil {
 		t.Fatalf("Reap failed: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestReapSkipsActiveWorkers(t *testing.T) {
 	tm.sessions["rf-integrator"] = true
 	_ = tm.NewWindow("rf-integrator", "#99: some issue")
 
-	results, err := Reap(tm, "rf-integrator", repoDir)
+	results, err := Reap(tm, "rf-integrator", repoDir, ReapConfig{})
 	if err != nil {
 		t.Fatalf("Reap failed: %v", err)
 	}
@@ -159,12 +159,49 @@ func TestReapHandlesNoWorktreesDir(t *testing.T) {
 	repoDir := t.TempDir()
 	tm := newMockTmuxRunner()
 
-	results, err := Reap(tm, "rf-integrator", repoDir)
+	results, err := Reap(tm, "rf-integrator", repoDir, ReapConfig{})
 	if err != nil {
 		t.Fatalf("Reap failed: %v", err)
 	}
 
 	if results != nil {
 		t.Errorf("expected nil results when no worktrees dir, got %v", results)
+	}
+}
+
+func TestReapDryRunReportsWithoutDeleting(t *testing.T) {
+	t.Parallel()
+
+	repoDir := t.TempDir()
+	worktreesDir := filepath.Join(repoDir, ".worktrees")
+
+	if err := os.MkdirAll(filepath.Join(worktreesDir, "worker-77"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Session exists but no window for worker-77 (worker finished).
+	tm := newMockTmuxRunner()
+	tm.sessions["rf-integrator"] = true
+
+	results, err := Reap(tm, "rf-integrator", repoDir, ReapConfig{DryRun: true})
+	if err != nil {
+		t.Fatalf("Reap failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	r := results[0]
+	if r.Reaped {
+		t.Error("expected dry-run to NOT reap")
+	}
+	if r.Reason != "would reap (dry-run)" {
+		t.Errorf("expected reason 'would reap (dry-run)', got %q", r.Reason)
+	}
+
+	// Worktree directory should still exist (not deleted).
+	if _, err := os.Stat(filepath.Join(worktreesDir, "worker-77")); os.IsNotExist(err) {
+		t.Error("expected worktree dir to still exist in dry-run mode")
 	}
 }


### PR DESCRIPTION
## Summary
- Replace `dryRun ...bool` variadic parameter in `Reap()` with explicit `ReapConfig{DryRun: bool}` struct for clarity at call sites
- Update all callers in `cmd/reap.go` and `cmd/missioncontrol.go` to pass `ReapConfig{}`
- Add dedicated test for dry-run mode (`TestReapDryRunReportsWithoutDeleting`)

## Test plan
- [x] Existing tests updated to use `ReapConfig{}` and pass
- [x] New dry-run test verifies "would reap" reason without deleting worktree directory
- [x] Full test suite passes (`go test ./...`)
- [x] Lint clean (`make lint` — 0 issues)

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)