### PR TITLE
feat: add pre-flight check for tmux installation

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -35,8 +36,21 @@ func init() {
 	rootCmd.AddCommand(upCmd)
 }
 
+// checkTmux verifies that tmux is installed and available on PATH.
+func checkTmux() error {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		return fmt.Errorf("tmux is required but not installed. Install with: brew install tmux (macOS) or apt install tmux (Linux)")
+	}
+	return nil
+}
+
 func runUp(cmd *cobra.Command, _ []string) error {
 	out := cmd.OutOrStdout()
+
+	// Pre-flight: tmux must be installed.
+	if err := checkTmux(); err != nil {
+		return err
+	}
 
 	// Pre-flight: must be in a git repo.
 	repoDir, err := repoRoot()

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"bytes"
+	"os/exec"
+	"strings"
 	"testing"
 )
 
@@ -51,5 +53,39 @@ func TestSelfUpdate_EmptySourceDir_SilentSkip(t *testing.T) {
 	// Skips must be silent — no output.
 	if buf.Len() != 0 {
 		t.Errorf("expected no output for skipped update, got %q", buf.String())
+	}
+}
+
+func TestCheckTmux_returnsNilWhenInstalled(t *testing.T) {
+	t.Parallel()
+
+	// tmux is installed in the dev/CI environment, so this should pass.
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed — cannot test happy path")
+	}
+
+	if err := checkTmux(); err != nil {
+		t.Errorf("expected nil error when tmux is installed, got: %v", err)
+	}
+}
+
+func TestCheckTmux_returnsErrorWithInstallInstructions(t *testing.T) {
+	// Not parallel — t.Setenv mutates process environment.
+	t.Setenv("PATH", t.TempDir())
+
+	err := checkTmux()
+	if err == nil {
+		t.Fatal("expected error when tmux is not on PATH")
+	}
+
+	msg := err.Error()
+	if !strings.Contains(msg, "tmux is required but not installed") {
+		t.Errorf("expected error to mention tmux is required, got: %q", msg)
+	}
+	if !strings.Contains(msg, "brew install tmux") {
+		t.Errorf("expected macOS install instructions, got: %q", msg)
+	}
+	if !strings.Contains(msg, "apt install tmux") {
+		t.Errorf("expected Linux install instructions, got: %q", msg)
 	}
 }


### PR DESCRIPTION
## Summary
- Add `checkTmux()` function using `exec.LookPath` to verify tmux is installed before proceeding with `rf launch`
- Returns a clear error message with install instructions for both macOS (`brew install tmux`) and Linux (`apt install tmux`)
- Called early in `runUp` before any tmux operations

## Test plan
- [x] Test verifies `checkTmux()` returns nil when tmux is installed
- [x] Test verifies `checkTmux()` returns error with install instructions when tmux is not on PATH
- [x] All existing tests pass
- [x] Lint clean (0 issues)

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)