### PR TITLE
fix: log selfUpdate failures instead of silently swallowing

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -182,11 +182,21 @@ func printLaunchBanner(w io.Writer) {
 func selfUpdate(w io.Writer) {
 	binaryPath, err := os.Executable()
 	if err != nil {
+		_, _ = fmt.Fprintf(w, "  Self-update check failed: %v\n", err)
 		return
 	}
 
 	result, err := selfupdate.Check(SourceDir, Version, binaryPath)
-	if err != nil || result == nil {
+	if err != nil {
+		_, _ = fmt.Fprintf(w, "  Self-update check failed: %v\n", err)
+		return
+	}
+
+	if result == nil {
+		return
+	}
+
+	if result.Skipped != "" {
 		return
 	}
 

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+)
+
+// NOTE: selfUpdate reads package-level SourceDir and Version vars.
+// These tests must NOT be parallel (they mutate package state).
+
+func TestSelfUpdate_BadSourceDir_SilentSkip(t *testing.T) {
+	// Not parallel — mutates package-level SourceDir.
+
+	origSourceDir := SourceDir
+	origVersion := Version
+	defer func() {
+		SourceDir = origSourceDir
+		Version = origVersion
+	}()
+
+	SourceDir = "/nonexistent/path/that/does/not/exist"
+	Version = "test"
+
+	var buf bytes.Buffer
+	selfUpdate(&buf)
+
+	// A non-existent source dir is a normal skip ("source directory not found").
+	// Skips must be silent — no output.
+	if buf.Len() != 0 {
+		t.Errorf("expected no output for skipped update, got %q", buf.String())
+	}
+}
+
+func TestSelfUpdate_EmptySourceDir_SilentSkip(t *testing.T) {
+	// Not parallel — mutates package-level SourceDir.
+
+	origSourceDir := SourceDir
+	origVersion := Version
+	defer func() {
+		SourceDir = origSourceDir
+		Version = origVersion
+	}()
+
+	SourceDir = ""
+	Version = "test"
+
+	var buf bytes.Buffer
+	selfUpdate(&buf)
+
+	// Empty source dir is a normal skip ("no source directory configured").
+	// Skips must be silent — no output.
+	if buf.Len() != 0 {
+		t.Errorf("expected no output for skipped update, got %q", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary
- **`selfUpdate` in `cmd/up.go` no longer silently swallows errors.** When `os.Executable()` or `selfupdate.Check()` returns an error, the message is written to the output writer so users can diagnose update failures.
- **Skip reasons (normal operation) remain silent** — no output for "already up to date", "source directory not found", etc.
- **Added tests in `cmd/up_test.go`** verifying that skipped updates produce no output.

Closes #145

## Test plan
- [x] `TestSelfUpdate_BadSourceDir_SilentSkip` — non-existent source dir produces no output
- [x] `TestSelfUpdate_EmptySourceDir_SilentSkip` — empty source dir produces no output
- [x] All existing tests pass (`go test ./...`)
- [x] Lint clean (`make lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)