### PR TITLE
fix: normalize column name casing in FormatBoard

### DIFF
--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -106,13 +106,20 @@ func NextReady(board *BoardSummary) *Item {
 func FormatBoard(board *BoardSummary) string {
 	var b strings.Builder
 
-	columnOrder := []string{"Someday/Maybe", "Backlog", "Ready", "Scoped", "In Progress", "In progress", "Review", "In review", "Done"}
+	columnOrder := []string{"Someday/Maybe", "Backlog", "Ready", "Scoped", "In Progress", "In Review", "Done"}
 
 	_, _ = fmt.Fprintln(&b, "=== Project Board ===")
 	_, _ = fmt.Fprintln(&b)
 
 	for _, col := range columnOrder {
-		items := board.Columns[col]
+		// Collect items from all board columns that match this canonical name (case-insensitive).
+		var items []Item
+		for boardCol, boardItems := range board.Columns {
+			if strings.EqualFold(boardCol, col) {
+				items = append(items, boardItems...)
+			}
+		}
+
 		_, _ = fmt.Fprintf(&b, "%s (%d)\n", col, len(items))
 
 		for _, item := range items {
@@ -160,7 +167,7 @@ func fetchProjectTitle(run GHRunner, owner string, projectNumber int) string {
 
 func isStandardColumn(col string, standard []string) bool {
 	for _, s := range standard {
-		if col == s {
+		if strings.EqualFold(col, s) {
 			return true
 		}
 	}

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -103,6 +103,66 @@ func TestFormatBoardShowsEmptyColumns(t *testing.T) {
 	}
 }
 
+func TestFormatBoardNormalizesColumnCasing(t *testing.T) {
+	t.Parallel()
+
+	board := &BoardSummary{
+		Columns: map[string][]Item{
+			"in progress": {
+				{Number: 99, Title: "Lowercase variant"},
+			},
+			"IN PROGRESS": {
+				{Number: 98, Title: "Uppercase variant"},
+			},
+			"in Review": {
+				{Number: 88, Title: "Review variant"},
+			},
+		},
+	}
+
+	out := FormatBoard(board)
+
+	// Both "in progress" and "IN PROGRESS" items should merge under "In Progress"
+	if !strings.Contains(out, "In Progress (2)") {
+		t.Errorf("expected 'In Progress (2)' in output\n\nGot:\n%s", out)
+	}
+
+	// "in Review" should merge under "In Review"
+	if !strings.Contains(out, "In Review (1)") {
+		t.Errorf("expected 'In Review (1)' in output\n\nGot:\n%s", out)
+	}
+
+	// Should NOT appear in catch-all section with their original casing
+	lines := strings.Split(out, "\n")
+	for _, line := range lines {
+		lower := strings.ToLower(line)
+		if strings.HasPrefix(lower, "in progress (") || strings.HasPrefix(lower, "in review (") {
+			// This is fine if it matches the canonical column heading exactly
+			if !strings.HasPrefix(line, "In Progress (") && !strings.HasPrefix(line, "In Review (") {
+				t.Errorf("case variant appeared as separate column: %q\n\nGot:\n%s", line, out)
+			}
+		}
+	}
+}
+
+func TestIsStandardColumnCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	standard := []string{"Scoped", "In Progress", "Done"}
+
+	if !isStandardColumn("in progress", standard) {
+		t.Error("expected 'in progress' to match 'In Progress'")
+	}
+
+	if !isStandardColumn("IN PROGRESS", standard) {
+		t.Error("expected 'IN PROGRESS' to match 'In Progress'")
+	}
+
+	if isStandardColumn("Custom", standard) {
+		t.Error("expected 'Custom' to not be standard")
+	}
+}
+
 func TestIsStandardColumn(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- `FormatBoard` now uses `strings.EqualFold` for case-insensitive column matching, merging items from casing variants (e.g. "In progress", "IN PROGRESS") into the canonical column heading
- `isStandardColumn` also uses case-insensitive comparison, preventing casing variants from appearing in the catch-all section
- Removed duplicate column entries ("In progress", "In review") from `columnOrder` — replaced with single canonical names and case-insensitive matching

## Test plan
- [x] Added `TestFormatBoardNormalizesColumnCasing` — verifies items from differently-cased columns merge under the canonical heading
- [x] Added `TestIsStandardColumnCaseInsensitive` — verifies case-insensitive matching in the standard column check
- [x] All existing tests pass unchanged
- [x] Lint clean (`golangci-lint`, 0 issues)

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)