### PR TITLE
refactor: route fetchIssue and checkPRForBranch through GHRunner

### DIFF
--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/drdanmaggs/rocket-fuel/internal/project"
 )
 
 func TestParseIssueRef_plainNumber(t *testing.T) {
@@ -161,3 +163,55 @@ func TestLoadMaxWorkers_defaultOnZeroValue(t *testing.T) {
 		t.Errorf("expected default %d for zero value, got %d", defaultMaxWorkers, got)
 	}
 }
+
+func TestFetchIssue_parsesGHOutput(t *testing.T) {
+	t.Parallel()
+
+	mockGH := func(_ ...string) ([]byte, error) {
+		return []byte(`{"number":42,"title":"Fix bug","body":"Details","labels":[{"name":"bug"}]}`), nil
+	}
+
+	issue, err := fetchIssueWith(mockGH, 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if issue.Number != 42 {
+		t.Errorf("expected number 42, got %d", issue.Number)
+	}
+	if issue.Title != "Fix bug" {
+		t.Errorf("expected title 'Fix bug', got %q", issue.Title)
+	}
+	if len(issue.Labels) != 1 || issue.Labels[0] != "bug" {
+		t.Errorf("expected labels [bug], got %v", issue.Labels)
+	}
+}
+
+func TestCheckPRForBranch_findsPR(t *testing.T) {
+	t.Parallel()
+
+	mockGH := func(_ ...string) ([]byte, error) {
+		return []byte(`[{"number":99,"title":"My PR","url":"https://github.com/x/y/pull/99"}]`), nil
+	}
+
+	result := checkPRForBranchWith(mockGH, "rf/issue-42")
+	if result != "PR #99: My PR" {
+		t.Errorf("expected 'PR #99: My PR', got %q", result)
+	}
+}
+
+func TestCheckPRForBranch_noPR(t *testing.T) {
+	t.Parallel()
+
+	mockGH := func(_ ...string) ([]byte, error) {
+		return []byte(`[]`), nil
+	}
+
+	result := checkPRForBranchWith(mockGH, "rf/issue-42")
+	if result != "" {
+		t.Errorf("expected empty string, got %q", result)
+	}
+}
+
+// Ensure the type satisfies project.GHRunner at compile time.
+var _ project.GHRunner = func(_ ...string) ([]byte, error) { return nil, nil }

--- a/cmd/missioncontrol.go
+++ b/cmd/missioncontrol.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"os/signal"
 	"strings"
 	"syscall"
@@ -156,12 +155,13 @@ func buildReapNudge(r worker.ReapResult) string {
 
 // checkPRForBranch checks if a PR exists for the given branch.
 func checkPRForBranch(branch string) string {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+	return checkPRForBranchWith(ghRunner, branch)
+}
 
-	out, err := exec.CommandContext(ctx,
-		"gh", "pr", "list", "--head", branch, "--json", "number,title,url", "--limit", "1",
-	).Output()
+// checkPRForBranchWith checks for a PR using the provided GHRunner.
+// Extracted for testability — tests inject a mock runner.
+func checkPRForBranchWith(run func(...string) ([]byte, error), branch string) string {
+	out, err := run("pr", "list", "--head", branch, "--json", "number,title,url", "--limit", "1")
 	if err != nil {
 		return ""
 	}

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1,14 +1,11 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/drdanmaggs/rocket-fuel/internal/session"
 	"github.com/drdanmaggs/rocket-fuel/internal/tmux"
@@ -107,10 +104,13 @@ type ghLabel struct {
 }
 
 func fetchIssue(number int) (*worker.Issue, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+	return fetchIssueWith(ghRunner, number)
+}
 
-	out, err := exec.CommandContext(ctx, "gh", "issue", "view", strconv.Itoa(number), "--json", "number,title,body,labels").Output()
+// fetchIssueWith fetches a GitHub issue using the provided GHRunner.
+// Extracted for testability — tests inject a mock runner.
+func fetchIssueWith(run func(...string) ([]byte, error), number int) (*worker.Issue, error) {
+	out, err := run("issue", "view", strconv.Itoa(number), "--json", "number,title,body,labels")
 	if err != nil {
 		return nil, fmt.Errorf("gh issue view: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Extracted `fetchIssueWith` and `checkPRForBranchWith` that accept a `GHRunner` parameter
- Original functions delegate to the new ones with the real `ghRunner`
- Tests can now inject mock runners for full dispatch path testing

## Test plan
- [x] New test: `fetchIssueWith` parses mock GH output correctly
- [x] New test: `checkPRForBranchWith` finds PR from mock output
- [x] New test: `checkPRForBranchWith` returns empty for no PRs
- [x] All existing tests pass
- [x] Lint clean

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)