### PR TITLE
refactor: Worker prompt passes issue number, not full body

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -74,14 +74,12 @@ func RouteSkill(labels []string) string {
 }
 
 // buildPrompt creates the prompt string for Claude Code.
+// Passes issue number only — the worker reads the full issue via gh CLI.
 func buildPrompt(issue Issue, skill string) string {
 	var b strings.Builder
 
 	_, _ = fmt.Fprintf(&b, "You are a Rocket Fuel worker. Your task is issue #%d: %s\n\n", issue.Number, issue.Title)
-
-	if issue.Body != "" {
-		_, _ = fmt.Fprintf(&b, "Issue description:\n%s\n\n", issue.Body)
-	}
+	_, _ = fmt.Fprintf(&b, "Run `gh issue view %d` to read the full issue details.\n\n", issue.Number)
 
 	_, _ = fmt.Fprintln(&b, "## Instructions")
 	_, _ = fmt.Fprintln(&b)

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -53,7 +53,7 @@ func TestBuildPrompt(t *testing.T) {
 	checks := []string{
 		"#42",
 		"Add user login",
-		"OAuth2 flow",
+		"gh issue view 42",
 		"/tdd",
 		"gh pr create",
 		"GUPP",
@@ -78,8 +78,9 @@ func TestBuildPromptWithoutBody(t *testing.T) {
 
 	prompt := buildPrompt(issue, "/bug-fix")
 
-	if contains(prompt, "Issue description") {
-		t.Error("expected no 'Issue description' section when body is empty")
+	// Should still contain gh issue view for reading the full issue
+	if !contains(prompt, "gh issue view 1") {
+		t.Error("expected prompt to contain 'gh issue view 1'")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Workers read issues via gh issue view instead of inline body
- Shorter prompts, no escaping issues, always latest content

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)