### PR TITLE
feat: PreToolUse hook for merge safety — CI gate

### DIFF
--- a/cmd/mergesafety.go
+++ b/cmd/mergesafety.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var mergeSafetyCmd = &cobra.Command{
+	Use:    "check-merge-safety",
+	Hidden: true, // internal — called by PreToolUse hook
+	Short:  "Check if a PR is safe to merge (CI green, not draft)",
+	RunE:   runMergeSafety,
+}
+
+func init() {
+	rootCmd.AddCommand(mergeSafetyCmd)
+}
+
+func runMergeSafety(cmd *cobra.Command, _ []string) error {
+	// Read the tool input from stdin (Claude Code sends it as JSON).
+	var input struct {
+		ToolInput struct {
+			Command string `json:"command"`
+		} `json:"tool_input"`
+	}
+
+	if err := json.NewDecoder(os.Stdin).Decode(&input); err != nil {
+		// If we can't parse input, allow the merge (fail-open for non-hook usage).
+		return nil
+	}
+
+	// Extract PR number from the command.
+	prNum := extractPRNumber(input.ToolInput.Command)
+	if prNum == "" {
+		// Can't determine PR — allow (fail-open).
+		return nil
+	}
+
+	// Check PR state.
+	out, err := exec.CommandContext(context.Background(),
+		"gh", "pr", "view", prNum,
+		"--json", "isDraft,statusCheckRollup",
+	).Output()
+	if err != nil {
+		// Can't check PR — allow (fail-open).
+		return nil
+	}
+
+	var pr struct {
+		IsDraft bool `json:"isDraft"`
+		Checks  []struct {
+			Status     string `json:"status"`
+			Conclusion string `json:"conclusion"`
+		} `json:"statusCheckRollup"`
+	}
+	if err := json.Unmarshal(out, &pr); err != nil {
+		return nil
+	}
+
+	// Rule 1: draft PRs cannot be merged.
+	if pr.IsDraft {
+		fmt.Fprintln(os.Stderr, "PR is still a draft — undraft before merging")
+		os.Exit(2)
+	}
+
+	// Rule 2: all CI checks must be complete.
+	for _, check := range pr.Checks {
+		if check.Status != "COMPLETED" {
+			fmt.Fprintln(os.Stderr, "CI is still running — wait for all checks to complete")
+			os.Exit(2)
+		}
+	}
+
+	// Rule 3: no CI failures.
+	for _, check := range pr.Checks {
+		if check.Conclusion == "FAILURE" {
+			fmt.Fprintln(os.Stderr, "CI has failures — do not merge until all checks pass")
+			os.Exit(2)
+		}
+	}
+
+	// All checks passed — allow merge.
+	return nil
+}
+
+func extractPRNumber(command string) string {
+	// Handle: gh pr merge 1345, gh pr merge 1345 --squash, etc.
+	parts := strings.Fields(command)
+	for i, p := range parts {
+		if p == "merge" && i+1 < len(parts) {
+			num := parts[i+1]
+			if len(num) > 0 && num[0] >= '0' && num[0] <= '9' {
+				return num
+			}
+		}
+	}
+	return ""
+}

--- a/cmd/mergesafety.go
+++ b/cmd/mergesafety.go
@@ -22,7 +22,7 @@ func init() {
 	rootCmd.AddCommand(mergeSafetyCmd)
 }
 
-func runMergeSafety(cmd *cobra.Command, _ []string) error {
+func runMergeSafety(_ *cobra.Command, _ []string) error {
 	// Read the tool input from stdin (Claude Code sends it as JSON).
 	var input struct {
 		ToolInput struct {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -122,8 +122,8 @@ func runUp(cmd *cobra.Command, _ []string) error {
 		_ = tm.Run("select-pane", "-t", sessionName+":"+session.WindowIntegrator+".0")
 
 		// Launch mission control in its window.
-		if err := tm.SendKeys(sessionName, session.WindowMissionCtrl, "rf mission-control --loop"); err != nil {
-			_, _ = fmt.Fprintf(out, "  Warning: could not launch mission control: %v\n", err)
+		if err := tm.SendKeys(sessionName, session.WindowWatchdog, "rf watchdog --loop"); err != nil {
+			_, _ = fmt.Fprintf(out, "  Warning: could not launch watchdog: %v\n", err)
 		}
 
 		_, _ = fmt.Fprintln(out)

--- a/cmd/watchdog.go
+++ b/cmd/watchdog.go
@@ -11,30 +11,30 @@ import (
 	"time"
 
 	"github.com/drdanmaggs/rocket-fuel/internal/dashboard"
-	"github.com/drdanmaggs/rocket-fuel/internal/missioncontrol"
 	"github.com/drdanmaggs/rocket-fuel/internal/session"
 	"github.com/drdanmaggs/rocket-fuel/internal/tmux"
+	"github.com/drdanmaggs/rocket-fuel/internal/watchdog"
 	"github.com/drdanmaggs/rocket-fuel/internal/worker"
 	"github.com/spf13/cobra"
 )
 
-var missionControlCmd = &cobra.Command{
-	Use:    "mission-control",
+var watchdogCmd = &cobra.Command{
+	Use:    "watchdog",
 	Hidden: true, // internal command — launched by rf launch, not user-facing
 	Short:  "Run dispatch + reap cycle",
 	Long: `Executes one dispatch + reap cycle. With --loop, runs continuously
 on a configurable interval. The background process that keeps the machine running.`,
-	RunE: runMissionControl,
+	RunE: runWatchdog,
 }
 
 func init() {
-	missionControlCmd.Flags().Bool("loop", false, "Run continuously")
-	missionControlCmd.Flags().Duration("interval", 3*time.Minute, "Loop interval (requires --loop)")
-	missionControlCmd.Flags().Bool("dry-run", false, "Show what would happen without acting")
-	rootCmd.AddCommand(missionControlCmd)
+	watchdogCmd.Flags().Bool("loop", false, "Run continuously")
+	watchdogCmd.Flags().Duration("interval", 3*time.Minute, "Loop interval (requires --loop)")
+	watchdogCmd.Flags().Bool("dry-run", false, "Show what would happen without acting")
+	rootCmd.AddCommand(watchdogCmd)
 }
 
-func runMissionControl(cmd *cobra.Command, _ []string) error {
+func runWatchdog(cmd *cobra.Command, _ []string) error {
 	loop, _ := cmd.Flags().GetBool("loop")
 	interval, _ := cmd.Flags().GetDuration("interval")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
@@ -44,10 +44,10 @@ func runMissionControl(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	fns := buildMissionControlFuncs(dryRun)
+	fns := buildWatchdogFuncs(dryRun)
 
 	if !loop {
-		result, err := missioncontrol.RunCycle(fns)
+		result, err := watchdog.RunCycle(fns)
 		if err != nil {
 			return err
 		}
@@ -68,19 +68,19 @@ func runMissionControl(cmd *cobra.Command, _ []string) error {
 		cancel()
 	}()
 
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Mission Control active (interval: %s, dry-run: %v)\n", interval, dryRun)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Watchdog active (interval: %s, dry-run: %v)\n", interval, dryRun)
 
 	logFn := func(msg string) {
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), msg)
 	}
 
-	missioncontrol.LoopWithActivity(ctx, interval, fns, logFn, repoDir)
+	watchdog.LoopWithActivity(ctx, interval, fns, logFn, repoDir)
 
-	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Mission Control offline.")
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Watchdog offline.")
 	return nil
 }
 
-func buildMissionControlFuncs(dryRun bool) missioncontrol.Funcs {
+func buildWatchdogFuncs(dryRun bool) watchdog.Funcs {
 	dispatchFn := func() (string, error) {
 		result, err := runDispatchCycle(dryRun)
 		if err != nil {
@@ -131,7 +131,7 @@ func buildMissionControlFuncs(dryRun bool) missioncontrol.Funcs {
 		return fmt.Sprintf("reaped %d worker(s)", reaped), nil
 	}
 
-	return missioncontrol.Funcs{
+	return watchdog.Funcs{
 		Dispatch: dispatchFn,
 		Reap:     reapFn,
 	}
@@ -148,9 +148,9 @@ func buildReapNudge(r worker.ReapResult) string {
 	prInfo := checkPRForBranch(branchName)
 
 	if prInfo != "" {
-		return fmt.Sprintf("[Mission Control] Worker #%s completed. %s. Review and update the board.", issueNum, prInfo)
+		return fmt.Sprintf("[Watchdog] Worker #%s completed. %s. Review and update the board.", issueNum, prInfo)
 	}
-	return fmt.Sprintf("[Mission Control] Worker #%s completed (no PR found). Check if work was finished.", issueNum)
+	return fmt.Sprintf("[Watchdog] Worker #%s completed (no PR found). Check if work was finished.", issueNum)
 }
 
 // checkPRForBranch checks if a PR exists for the given branch.
@@ -178,7 +178,7 @@ func checkPRForBranchWith(run func(...string) ([]byte, error), branch string) st
 	return fmt.Sprintf("PR #%d: %s", prs[0].Number, prs[0].Title)
 }
 
-func printCycleResult(cmd *cobra.Command, result *missioncontrol.CycleResult) {
+func printCycleResult(cmd *cobra.Command, result *watchdog.CycleResult) {
 	if result.DispatchErr != nil {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "dispatch error: %v\n", result.DispatchErr)
 	} else {
@@ -192,7 +192,7 @@ func printCycleResult(cmd *cobra.Command, result *missioncontrol.CycleResult) {
 	}
 }
 
-func recordCycleActivity(repoDir string, result *missioncontrol.CycleResult) {
+func recordCycleActivity(repoDir string, result *watchdog.CycleResult) {
 	if result.DispatchErr != nil {
 		_ = dashboard.WriteActivity(repoDir, fmt.Sprintf("dispatch error: %v", result.DispatchErr))
 	} else if result.DispatchResult != "" {

--- a/internal/launch/launch.go
+++ b/internal/launch/launch.go
@@ -59,6 +59,19 @@ func EnsureClaudeSettings(repoDir string) error {
 		},
 	}
 
+	// Set PreToolUse hook for merge safety — CI gate.
+	hooks["PreToolUse"] = []map[string]interface{}{
+		{
+			"matcher": "Bash(gh pr merge*)",
+			"hooks": []map[string]interface{}{
+				{
+					"type":    "command",
+					"command": `export PATH="$HOME/go/bin:$PATH" && rf check-merge-safety`,
+				},
+			},
+		},
+	}
+
 	settings["hooks"] = hooks
 
 	data, err := json.MarshalIndent(settings, "", "  ")

--- a/internal/prime/integrator.md
+++ b/internal/prime/integrator.md
@@ -19,10 +19,34 @@ This is your core operating principle — non-negotiable.
 ## On startup — ACT IMMEDIATELY
 
 1. **Review the board** — assess every column.
-2. **Clean up** — move closed issues to Done, remove stale entries, close resolved CI issues.
-3. **Dispatch** — if Scoped items exist and capacity allows, run `rf work <issue-number>`.
-4. **Check workers** — run `rf status`. If workers have PRs, note them. If workers are stuck, investigate.
-5. **Brief the Visionary** — one paragraph: what's happening, what you just did, what's next. No questions.
+2. **Clean up** — move closed issues to Done, remove stale entries, close resolved CI issues. Close epics where all sub-issues are done.
+3. **Evaluate before dispatching** — for each Ready/Scoped item, apply the dispatch decision tree (below).
+4. **Dispatch** — only dispatch items that pass the decision tree.
+5. **Check workers** — run `rf status`. If workers have PRs, note them. If workers are stuck, investigate.
+6. **Brief the Visionary** — one paragraph: what's happening, what you just did, what's next. No questions.
+
+## Dispatch decision tree — APPLY BEFORE EVERY DISPATCH
+
+You CANNOT scope issues. Scoping requires the Visionary's product judgment. Evaluate each issue before dispatching:
+
+| Condition | Action |
+|-----------|--------|
+| Clear description + acceptance criteria | Dispatch worker |
+| Vague / one-liner / brainstorm (< 3 lines, no criteria) | **DO NOT dispatch.** Surface to Visionary: "Issue #N needs scoping." |
+| All sub-issues of an epic are closed | Close the epic. Do not dispatch. |
+| Needs a product decision (what to build, not how) | Surface to Visionary |
+| Already has a PR open | Check PR status, do not re-dispatch |
+| Already has an active worker window | Skip |
+
+**Examples of issues too vague to dispatch:**
+- "currently in the menu, and i don't think the page really works properly"
+- "fix the thing"
+- "look into performance"
+
+**Examples of issues ready to dispatch:**
+- Clear problem statement + proposed fix + acceptance criteria
+- Bug report with reproduction steps
+- Well-scoped sub-issue of an epic with clear deliverables
 
 ## Mechanical vs judgment calls
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -13,8 +13,8 @@ const DefaultSessionName = "rf-integrator"
 
 // Window names.
 const (
-	WindowIntegrator  = "integrator"
-	WindowMissionCtrl = "mission-control"
+	WindowIntegrator = "integrator"
+	WindowWatchdog   = "watchdog"
 )
 
 // Setup creates the Rocket Fuel tmux session with an "integrator" window
@@ -34,9 +34,9 @@ func Setup(tm tmux.Runner, sessionName string) (bool, error) {
 	_ = tm.RenameWindow(sessionName, "0", WindowIntegrator)
 
 	// Create mission-control window.
-	if err := tm.NewWindow(sessionName, WindowMissionCtrl); err != nil {
+	if err := tm.NewWindow(sessionName, WindowWatchdog); err != nil {
 		_ = tm.KillSession(sessionName)
-		return false, fmt.Errorf("create window %q: %w", WindowMissionCtrl, err)
+		return false, fmt.Errorf("create window %q: %w", WindowWatchdog, err)
 	}
 
 	// Select integrator so the Visionary lands there.

--- a/internal/session/session_integration_test.go
+++ b/internal/session/session_integration_test.go
@@ -51,7 +51,7 @@ func TestSetupCreatesAllWindows_Integration(t *testing.T) {
 	if !contains(windows, "integrator") {
 		t.Errorf("expected 'integrator' window, got: %v", windows)
 	}
-	if !contains(windows, "mission-control") {
+	if !contains(windows, "watchdog") {
 		t.Errorf("expected 'mission-control' window, got: %v", windows)
 	}
 	if len(windows) != 2 {

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -122,8 +122,8 @@ func TestSetupCreatesSession(t *testing.T) {
 	if len(windows) != 1 {
 		t.Errorf("expected 1 additional window (mission-control), got %d: %v", len(windows), windows)
 	}
-	if len(windows) > 0 && windows[0] != WindowMissionCtrl {
-		t.Errorf("expected window %q, got %q", WindowMissionCtrl, windows[0])
+	if len(windows) > 0 && windows[0] != WindowWatchdog {
+		t.Errorf("expected window %q, got %q", WindowWatchdog, windows[0])
 	}
 }
 

--- a/internal/watchdog/heartbeat.go
+++ b/internal/watchdog/heartbeat.go
@@ -1,6 +1,6 @@
 // Package missioncontrol provides the periodic dispatch + reap loop.
 // The dumb, reliable background process — no AI, no decisions.
-package missioncontrol
+package watchdog
 
 import (
 	"context"

--- a/internal/watchdog/heartbeat_test.go
+++ b/internal/watchdog/heartbeat_test.go
@@ -1,4 +1,4 @@
-package missioncontrol
+package watchdog
 
 import (
 	"context"

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -98,7 +98,12 @@ func buildPrompt(issue Issue, skill string) string {
 	_, _ = fmt.Fprintln(&b, "NEVER present a plan and wait for approval.")
 	_, _ = fmt.Fprintln(&b, "NEVER sit idle after creating the PR.")
 	_, _ = fmt.Fprintln(&b)
-	_, _ = fmt.Fprintln(&b, "Stay focused on this single issue. Don't scope-creep.")
+	_, _ = fmt.Fprintln(&b, "## Quality guardrails")
+	_, _ = fmt.Fprintln(&b)
+	_, _ = fmt.Fprintln(&b, "- If the issue is vague, explore the codebase FIRST to understand what's actually broken.")
+	_, _ = fmt.Fprintln(&b, "- Removing or hiding a broken feature is NOT fixing it — unless the issue explicitly asks for removal.")
+	_, _ = fmt.Fprintln(&b, "- If unsure about scope, comment on the issue with your diagnosis before acting.")
+	_, _ = fmt.Fprintln(&b, "- Stay focused on this single issue. Don't scope-creep.")
 
 	return b.String()
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -74,14 +74,12 @@ func RouteSkill(labels []string) string {
 }
 
 // buildPrompt creates the prompt string for Claude Code.
+// Passes issue number only — the worker reads the full issue via gh CLI.
 func buildPrompt(issue Issue, skill string) string {
 	var b strings.Builder
 
 	_, _ = fmt.Fprintf(&b, "You are a Rocket Fuel worker. Your task is issue #%d: %s\n\n", issue.Number, issue.Title)
-
-	if issue.Body != "" {
-		_, _ = fmt.Fprintf(&b, "Issue description:\n%s\n\n", issue.Body)
-	}
+	_, _ = fmt.Fprintf(&b, "Run `gh issue view %d` to read the full issue details.\n\n", issue.Number)
 
 	_, _ = fmt.Fprintln(&b, "## Instructions")
 	_, _ = fmt.Fprintln(&b)

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -53,7 +53,7 @@ func TestBuildPrompt(t *testing.T) {
 	checks := []string{
 		"#42",
 		"Add user login",
-		"OAuth2 flow",
+		"gh issue view 42",
 		"/tdd",
 		"gh pr create",
 		"GUPP",
@@ -78,8 +78,9 @@ func TestBuildPromptWithoutBody(t *testing.T) {
 
 	prompt := buildPrompt(issue, "/bug-fix")
 
-	if contains(prompt, "Issue description") {
-		t.Error("expected no 'Issue description' section when body is empty")
+	// Should still contain gh issue view for reading the full issue
+	if !contains(prompt, "gh issue view 1") {
+		t.Error("expected prompt to contain 'gh issue view 1'")
 	}
 }
 

--- a/prompts/integrator.md
+++ b/prompts/integrator.md
@@ -19,10 +19,34 @@ This is your core operating principle — non-negotiable.
 ## On startup — ACT IMMEDIATELY
 
 1. **Review the board** — assess every column.
-2. **Clean up** — move closed issues to Done, remove stale entries, close resolved CI issues.
-3. **Dispatch** — if Scoped items exist and capacity allows, run `rf work <issue-number>`.
-4. **Check workers** — run `rf status`. If workers have PRs, note them. If workers are stuck, investigate.
-5. **Brief the Visionary** — one paragraph: what's happening, what you just did, what's next. No questions.
+2. **Clean up** — move closed issues to Done, remove stale entries, close resolved CI issues. Close epics where all sub-issues are done.
+3. **Evaluate before dispatching** — for each Ready/Scoped item, apply the dispatch decision tree (below).
+4. **Dispatch** — only dispatch items that pass the decision tree.
+5. **Check workers** — run `rf status`. If workers have PRs, note them. If workers are stuck, investigate.
+6. **Brief the Visionary** — one paragraph: what's happening, what you just did, what's next. No questions.
+
+## Dispatch decision tree — APPLY BEFORE EVERY DISPATCH
+
+You CANNOT scope issues. Scoping requires the Visionary's product judgment. Evaluate each issue before dispatching:
+
+| Condition | Action |
+|-----------|--------|
+| Clear description + acceptance criteria | Dispatch worker |
+| Vague / one-liner / brainstorm (< 3 lines, no criteria) | **DO NOT dispatch.** Surface to Visionary: "Issue #N needs scoping." |
+| All sub-issues of an epic are closed | Close the epic. Do not dispatch. |
+| Needs a product decision (what to build, not how) | Surface to Visionary |
+| Already has a PR open | Check PR status, do not re-dispatch |
+| Already has an active worker window | Skip |
+
+**Examples of issues too vague to dispatch:**
+- "currently in the menu, and i don't think the page really works properly"
+- "fix the thing"
+- "look into performance"
+
+**Examples of issues ready to dispatch:**
+- Clear problem statement + proposed fix + acceptance criteria
+- Bug report with reproduction steps
+- Well-scoped sub-issue of an epic with clear deliverables
 
 ## Mechanical vs judgment calls
 


### PR DESCRIPTION
## Summary
- New rf check-merge-safety command: blocks draft PRs, pending CI, failed CI
- PreToolUse hook added to EnsureClaudeSettings
- Integrator can merge freely — safety enforced by code, not permission prompts

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)