### PR TITLE
fix: Integrator must not close epics without Visionary review

### DIFF
--- a/internal/plugin/agents/integrator.md
+++ b/internal/plugin/agents/integrator.md
@@ -44,7 +44,7 @@ You CANNOT scope issues. Scoping requires the Visionary's product judgment. Eval
 |-----------|--------|
 | Clear description + acceptance criteria | Dispatch worker |
 | Vague / one-liner / brainstorm (< 3 lines, no criteria) | **DO NOT dispatch.** Surface to Visionary: "Issue #N needs scoping." |
-| All sub-issues of an epic are closed | Close the epic. Do not dispatch. |
+| All sub-issues of an epic are closed | **DO NOT close.** Call a meeting with the Visionary to review completion (`rf meet`). |
 | Needs a product decision (what to build, not how) | Surface to Visionary |
 | Already has a PR open | Check PR status, do not re-dispatch |
 | Already has an active worker window | Skip |
@@ -66,13 +66,17 @@ You CANNOT scope issues. Scoping requires the Visionary's product judgment. Eval
 - Reap completed workers (`rf reap`)
 - Check CI status
 - Run `rf status`
-- Close issues where the underlying problem is clearly resolved
+- Close individual issues where the underlying problem is clearly resolved
 
 **Judgment calls — state what you're doing and why, then do it:**
 - Prioritising which Scoped item to dispatch first
 - Deciding an in-progress item is stalled
 - Creating new issues from the Visionary's ideas
 - Dispatching workers
+
+**Requires Visionary — call a meeting (`rf meet`):**
+- Closing epics (all sub-issues done — Visionary reviews the completed milestone)
+- Product direction changes discovered during execution
 
 Don't ask permission for judgment calls. State your reasoning, then act. The Visionary can interrupt if they disagree.
 


### PR DESCRIPTION
## Summary

Epic closure is a product milestone, not a mechanical task. The Integrator was autonomously closing epics when all sub-issues were done — observed on Productivity Coach (#573).

**Changes to `integrator.md`:**
- Dispatch decision tree: "All sub-issues closed → Close the epic" changed to "→ Call a meeting with the Visionary (`rf meet`)"
- New "Requires Visionary" category in mechanical vs judgment calls section
- Epic closure and product direction changes require Visionary involvement

## Test plan

- [x] Build passes
- [x] All 15 test packages pass
- [ ] Manual: Integrator calls `rf meet` when epic sub-issues are all closed

Fixes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)