### PR TITLE
fix: plugin name kebab-case + validation

### DIFF
--- a/internal/plugin/.claude-plugin/plugin.json
+++ b/internal/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,8 @@
 {
-  "name": "Rocket Fuel",
+  "name": "rocket-fuel",
   "version": "0.1.0",
-  "description": "Multi-agent orchestrator for Claude Code"
+  "description": "Multi-agent orchestrator for Claude Code — skills, agents, and rules for TDD, code review, shipping, and project management",
+  "author": {
+    "name": "drdanmaggs"
+  }
 }

--- a/internal/plugin/skills/critical-path-testing/SKILL.md
+++ b/internal/plugin/skills/critical-path-testing/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: critical-path-testing
+description: "Risk-driven testing — identify and test critical user paths first, coverage is an output not the goal"
+---
+
 # Critical Path Testing Skill
 
 **Type:** Orchestrator (Multi-Phase)


### PR DESCRIPTION
## Summary

Fixes plugin validation errors so it can be installed via `claude plugin install`.

- Plugin name: "Rocket Fuel" → "rocket-fuel" (spaces not allowed in plugin names)
- Added author field to manifest
- Added frontmatter to critical-path-testing skill (was the only skill missing it)

Passes `claude plugin validate` cleanly.

## Test plan

- [x] `claude plugin validate internal/plugin/` passes with no errors or warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)