### PR TITLE
fix: add marketplace.json for plugin installation

### DIFF
--- a/internal/plugin/.claude-plugin/marketplace.json
+++ b/internal/plugin/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "rocket-fuel",
+  "description": "Rocket Fuel plugin marketplace — skills, agents, and rules for AI-assisted development",
+  "owner": {
+    "name": "drdanmaggs"
+  },
+  "plugins": [
+    {
+      "name": "rocket-fuel",
+      "description": "Multi-agent orchestrator for Claude Code — skills, agents, and rules for TDD, code review, shipping, and project management",
+      "source": ".",
+      "category": "development"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds marketplace.json so the plugin can be installed via:
```bash
claude plugin marketplace add drdanmaggs/rocket-fuel --sparse internal/plugin
claude plugin install rocket-fuel
```

Claude Code requires a marketplace.json to discover plugins in a repo.

## Test plan

- [ ] `claude plugin marketplace add drdanmaggs/rocket-fuel --sparse internal/plugin` succeeds
- [ ] `claude plugin install rocket-fuel` installs the plugin
- [ ] `/skills` shows skills from the plugin in a new session

🤖 Generated with [Claude Code](https://claude.com/claude-code)