### PR TITLE
fix: marketplace.json at repo root

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "rocket-fuel",
+  "description": "Rocket Fuel plugin marketplace — skills, agents, and rules for AI-assisted development",
+  "owner": {
+    "name": "drdanmaggs"
+  },
+  "plugins": [
+    {
+      "name": "rocket-fuel",
+      "description": "Multi-agent orchestrator for Claude Code — skills, agents, and rules for TDD, code review, shipping, and project management",
+      "source": "./internal/plugin",
+      "category": "development"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Claude Code looks for `.claude-plugin/marketplace.json` at the repo root, regardless of `--sparse` flag. Moves the marketplace manifest to the root with `source` pointing to `./internal/plugin`.

Install command becomes simply:
```bash
claude plugin marketplace add drdanmaggs/rocket-fuel
claude plugin install rocket-fuel
```

No `--sparse` flag needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)