### PR TITLE
feat: add worktree-reset skill to plugin

### DIFF
--- a/internal/plugin/extract_test.go
+++ b/internal/plugin/extract_test.go
@@ -356,8 +356,8 @@ func TestExtractPlugin_extractsAllSkillDirectoriesWithReferencesIntact(t *testin
 	}
 
 	// ci-verify/ is empty on disk so Go's embed skips it; 26 directories extract
-	if len(skillDirs) != 26 {
-		t.Fatalf("expected 26 skill directories, got %d: %v", len(skillDirs), skillDirs)
+	if len(skillDirs) != 27 {
+		t.Fatalf("expected 27 skill directories, got %d: %v", len(skillDirs), skillDirs)
 	}
 
 	// Assert: each skill directory contains a SKILL.md file

--- a/internal/plugin/skills/worktree-reset/SKILL.md
+++ b/internal/plugin/skills/worktree-reset/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: worktree-reset
+description: "Reset this worktree after a merged PR — cleans branch, fetches latest, prepares for new work"
+allowed-tools: Bash(git *), Bash(gh *)
+---
+
+# Post-merge worktree reset
+
+Current state:
+- Branch: !`git branch --show-current`
+- Worktrees: !`git worktree list`
+- Status: !`git status --porcelain`
+
+## Instructions
+
+1. Verify the current branch's PR has been merged using `gh pr view --json state`
+2. If not merged, ask the user if they want to proceed anyway
+3. Delete the remote branch: `git push origin --delete <branch>`
+   - If this fails (already deleted), that's fine - continue
+4. Fetch latest changes: `git fetch origin --prune`
+5. Detach HEAD at origin/main: `git switch --detach origin/main`
+6. Delete the local branch: `git branch -D <branch>`
+7. Clean the working tree: `git clean -fd && git restore .`
+8. Report what was cleaned up and confirm the worktree is ready for new work
+
+## Safety checks
+
+- NEVER reset if current branch is `main` or `master`
+- If already in detached HEAD state, just clean and confirm ready
+- Always verify PR state before proceeding


### PR DESCRIPTION
## Summary

Adds worktree-reset to the plugin (27 skills total). After merge, run `claude plugin update rocket-fuel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)