### PR TITLE
chore: bump plugin version to 0.2.0

### DIFF
--- a/internal/plugin/.claude-plugin/plugin.json
+++ b/internal/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rocket-fuel",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Multi-agent orchestrator for Claude Code — skills, agents, and rules for TDD, code review, shipping, and project management",
   "author": {
     "name": "drdanmaggs"


### PR DESCRIPTION
Triggers update detection for `claude plugin update rocket-fuel@rocket-fuel`.