### PR TITLE
chore: add Dependabot for gomod and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      go-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering `gomod` and `github-actions`
- Weekly cadence, minor/patch grouped into a single PR per ecosystem
- Majors land individually so breaking changes get reviewed alone
- Cap of 5 open PRs per ecosystem

## Test plan
- [ ] Merge and confirm Dependabot opens its first round of PRs on the next weekly tick
- [ ] Verify grouped minor/patch PRs land as one, majors as separate

🤖 Generated with [Claude Code](https://claude.com/claude-code)