### PR TITLE
fix: cache board fetches to stop hooks hammering the GitHub API (#213)

### DIFF
--- a/cmd/precompact.go
+++ b/cmd/precompact.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"syscall"
+	"time"
 
 	"github.com/drdanmaggs/rocket-fuel/internal/hookutil"
 	"github.com/drdanmaggs/rocket-fuel/internal/prime"
@@ -70,7 +71,7 @@ func runPrecompactWith(input io.Reader, out io.Writer) error {
 
 	// Load board state (optional — project may not be linked).
 	if cfg, loadErr := loadProjectConfig(); loadErr == nil {
-		board, fetchErr := project.FetchBoard(ghRunner, cfg.Owner, cfg.ProjectNumber)
+		board, fetchErr := project.FetchBoardCached(ghRunner, cfg.Owner, cfg.ProjectNumber, repoDir, project.SessionBoardTTL, time.Now())
 		if fetchErr == nil {
 			in.Board = board
 		}

--- a/cmd/prime.go
+++ b/cmd/prime.go
@@ -55,7 +55,7 @@ func runPrimeWith(input io.Reader, out io.Writer) error {
 	if role == hookutil.RoleIntegrator {
 		// Load board state (optional — project may not be linked).
 		if cfg, loadErr := loadProjectConfig(); loadErr == nil {
-			board, fetchErr := project.FetchBoard(ghRunner, cfg.Owner, cfg.ProjectNumber)
+			board, fetchErr := project.FetchBoardCached(ghRunner, cfg.Owner, cfg.ProjectNumber, repoDir, project.SessionBoardTTL, time.Now())
 			if fetchErr == nil {
 				in.Board = board
 			}

--- a/cmd/shouldcontinue.go
+++ b/cmd/shouldcontinue.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/drdanmaggs/rocket-fuel/internal/hookutil"
 	"github.com/drdanmaggs/rocket-fuel/internal/project"
@@ -44,7 +45,7 @@ func runShouldContinueWith(input io.Reader) error {
 	// Check board for Ready items.
 	cfg, err := loadProjectConfig()
 	if err == nil {
-		board, fetchErr := project.FetchBoard(ghRunner, cfg.Owner, cfg.ProjectNumber)
+		board, fetchErr := project.FetchBoardCached(ghRunner, cfg.Owner, cfg.ProjectNumber, repoDir, project.StopHookBoardTTL, time.Now())
 		if fetchErr == nil {
 			next := project.NextReady(board)
 			if next != nil {

--- a/internal/project/cache.go
+++ b/internal/project/cache.go
@@ -1,0 +1,72 @@
+package project
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// boardCacheFile is the on-disk cache location relative to the repo root.
+const boardCacheFile = "board-cache.json"
+
+// boardCacheEnvelope wraps a cached board with the time it was fetched.
+type boardCacheEnvelope struct {
+	FetchedAt time.Time     `json:"fetched_at"`
+	Board     *BoardSummary `json:"board"`
+}
+
+// FetchBoardCached returns the project board, serving from a local cache file
+// when the cached copy is younger than ttl and otherwise fetching fresh via
+// run and refreshing the cache.
+//
+// Hooks that fire on every Claude response (the Stop hook in particular) call
+// this to avoid exhausting the GitHub API rate limit — see issue #213. now is
+// injected so the TTL behaviour is deterministic in tests.
+//
+// Caching is a best-effort optimisation: a corrupt or unwritable cache never
+// fails the call, it just falls through to a fresh fetch.
+func FetchBoardCached(run GHRunner, owner string, projectNumber int, repoDir string, ttl time.Duration, now time.Time) (*BoardSummary, error) {
+	cachePath := filepath.Join(repoDir, ".rocket-fuel", boardCacheFile)
+
+	if cached := readBoardCache(cachePath); cached != nil && cached.Board != nil {
+		if now.Sub(cached.FetchedAt) < ttl {
+			return cached.Board, nil
+		}
+	}
+
+	board, err := FetchBoard(run, owner, projectNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	writeBoardCache(cachePath, boardCacheEnvelope{FetchedAt: now, Board: board})
+	return board, nil
+}
+
+// readBoardCache loads the cache envelope, returning nil on any error so the
+// caller falls through to a fresh fetch.
+func readBoardCache(cachePath string) *boardCacheEnvelope {
+	data, err := os.ReadFile(cachePath)
+	if err != nil {
+		return nil
+	}
+	var env boardCacheEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return nil
+	}
+	return &env
+}
+
+// writeBoardCache persists the envelope, ignoring errors — caching must never
+// break the calling hook.
+func writeBoardCache(cachePath string, env boardCacheEnvelope) {
+	data, err := json.MarshalIndent(env, "", "  ")
+	if err != nil {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
+		return
+	}
+	_ = os.WriteFile(cachePath, data, 0o644)
+}

--- a/internal/project/cache.go
+++ b/internal/project/cache.go
@@ -10,6 +10,16 @@ import (
 // boardCacheFile is the on-disk cache location relative to the repo root.
 const boardCacheFile = "board-cache.json"
 
+// Board cache TTLs for the hook-driven callers (#213).
+const (
+	// StopHookBoardTTL caches the board for the Stop hook, which fires after
+	// every Claude response and is the worst rate-limit offender.
+	StopHookBoardTTL = 60 * time.Second
+	// SessionBoardTTL caches the board for the session-priming hooks (prime,
+	// precompact), which fire far less often than the Stop hook.
+	SessionBoardTTL = 30 * time.Second
+)
+
 // boardCacheEnvelope wraps a cached board with the time it was fetched.
 type boardCacheEnvelope struct {
 	FetchedAt time.Time     `json:"fetched_at"`

--- a/internal/project/cache_test.go
+++ b/internal/project/cache_test.go
@@ -1,0 +1,142 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// countingRunner returns a valid board response and increments *calls on each
+// item-list fetch, so tests can assert how many times the API was hit.
+func countingRunner(calls *int) GHRunner {
+	return func(args ...string) ([]byte, error) {
+		if args[0] == "project" && args[1] == "item-list" {
+			*calls++
+			return []byte(`{
+				"items": [
+					{"id":"1","title":"Issue A","status":"Ready","content":{"number":1,"labels":["workflow:tdd"]}}
+				],
+				"totalCount": 1
+			}`), nil
+		}
+		if args[0] == "project" && args[1] == "view" {
+			return []byte(`{"title":"Test Project"}`), nil
+		}
+		return nil, nil
+	}
+}
+
+func TestFetchBoardCachedFetchesFreshOnCacheMiss(t *testing.T) {
+	t.Parallel()
+
+	repoDir := t.TempDir()
+	calls := 0
+	now := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+
+	board, err := FetchBoardCached(countingRunner(&calls), "owner", 1, repoDir, 60*time.Second, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 fetch on cache miss, got %d", calls)
+	}
+	if board == nil || len(board.Columns["Ready"]) != 1 {
+		t.Fatal("expected board with one Ready item")
+	}
+
+	// The cache file should now exist.
+	cachePath := filepath.Join(repoDir, ".rocket-fuel", "board-cache.json")
+	if _, statErr := os.Stat(cachePath); statErr != nil {
+		t.Errorf("expected cache file to be written: %v", statErr)
+	}
+}
+
+func TestFetchBoardCachedServesFromCacheWithinTTL(t *testing.T) {
+	t.Parallel()
+
+	repoDir := t.TempDir()
+	calls := 0
+	now := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+	run := countingRunner(&calls)
+
+	// First call populates the cache.
+	if _, err := FetchBoardCached(run, "owner", 1, repoDir, 60*time.Second, now); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Second call 30s later (within the 60s TTL) must hit the cache.
+	board, err := FetchBoardCached(run, "owner", 1, repoDir, 60*time.Second, now.Add(30*time.Second))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if calls != 1 {
+		t.Errorf("expected cache hit (1 fetch total), got %d fetches", calls)
+	}
+	if board == nil || len(board.Columns["Ready"]) != 1 {
+		t.Fatal("expected cached board to round-trip the Ready item")
+	}
+}
+
+func TestFetchBoardCachedRefetchesAfterTTLExpiry(t *testing.T) {
+	t.Parallel()
+
+	repoDir := t.TempDir()
+	calls := 0
+	now := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+	run := countingRunner(&calls)
+
+	if _, err := FetchBoardCached(run, "owner", 1, repoDir, 60*time.Second, now); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// 61s later — past the 60s TTL, so it must fetch fresh.
+	if _, err := FetchBoardCached(run, "owner", 1, repoDir, 60*time.Second, now.Add(61*time.Second)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if calls != 2 {
+		t.Errorf("expected 2 fetches after TTL expiry, got %d", calls)
+	}
+}
+
+func TestFetchBoardCachedRefetchesWhenCacheCorrupt(t *testing.T) {
+	t.Parallel()
+
+	repoDir := t.TempDir()
+	cacheDir := filepath.Join(repoDir, ".rocket-fuel")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "board-cache.json"), []byte("{not valid json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := 0
+	now := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+
+	board, err := FetchBoardCached(countingRunner(&calls), "owner", 1, repoDir, 60*time.Second, now)
+	if err != nil {
+		t.Fatalf("expected corrupt cache to be ignored, got error: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected fresh fetch when cache is corrupt, got %d fetches", calls)
+	}
+	if board == nil {
+		t.Fatal("expected a board despite corrupt cache")
+	}
+}
+
+func TestFetchBoardCachedPropagatesFetchError(t *testing.T) {
+	t.Parallel()
+
+	repoDir := t.TempDir()
+	now := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+
+	failing := func(_ ...string) ([]byte, error) {
+		return nil, os.ErrPermission
+	}
+
+	if _, err := FetchBoardCached(failing, "owner", 1, repoDir, 60*time.Second, now); err == nil {
+		t.Error("expected error to propagate when the underlying fetch fails")
+	}
+}


### PR DESCRIPTION
## Summary

Addresses the core of #213: the GitHub API rate limit (5,000 req/hr) was being exhausted because hooks fetch board state on a hot path. The **Stop hook** (`rf should-continue`) was the worst offender — it fires after *every* Claude response, and each invocation did a GraphQL `FetchBoard`. An active Integrator generates 10–50+ responses/hour.

## Change

Add `project.FetchBoardCached` — a file-based TTL cache (`.rocket-fuel/board-cache.json`). Because each hook runs as a separate process, the cache must live on disk, not in memory. It's best-effort: a corrupt or unwritable cache falls through to a fresh fetch and never fails the calling hook. `now` is injected for deterministic TTL tests.

Wired into the three hot-path callers:

| Hook | Command | TTL |
|------|---------|-----|
| Stop (every response) | `should-continue` | 60s |
| SessionStart | `prime` | 30s |
| PreCompact | `precompact` | 30s |

One-shot user commands (`project view`, launch banner) and the dispatch cycle (mutates state, needs fresh data) deliberately keep calling `FetchBoard` directly.

**Impact:** Stop-hook board fetches drop from 10–50+/hour to ~60/hour regardless of activity.

## Tests

5 new unit tests covering cache miss, cache hit within TTL, refetch after TTL expiry, corrupt-cache fallthrough, and fetch-error propagation. Full `-race` suite green.

## Not in this PR (follow-up)

The remaining #213 acceptance criteria are tracked separately: watchdog idle-backoff, the `rf api-usage` counter/command, and the `stop_hook_active` re-entrancy guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)