### PR TITLE
refactor(tdd): speed up the loop and stop hardcoding the environment

### DIFF
--- a/internal/plugin/agents/tdd-implementer.md
+++ b/internal/plugin/agents/tdd-implementer.md
@@ -37,8 +37,8 @@ Before writing anything, read the files listed in your phase brief:
 
 Run tests using the command from your phase brief, scoped by test type:
 - **Unit tests:** run the test file only
-- **Integration tests:** run the full suite
-- **E2E tests:** run the E2E suite
+- **Integration tests:** run the affected feature's test file(s) only — **not** the full suite (full regression is the CI/PR gate)
+- **E2E tests:** run the relevant spec only
 
 This test + all previous tests pass = GREEN gate passed. This test fails = fix your implementation. Previous test fails = you broke something, fix it without modifying tests.
 

--- a/internal/plugin/agents/tdd-plan-reviewer.md
+++ b/internal/plugin/agents/tdd-plan-reviewer.md
@@ -32,9 +32,9 @@ Read the files listed in your phase brief:
 - **Relevant source files** — understand existing code structure, naming conventions, patterns
 - **Related test files** — learn how similar features are tested
 
-### 2. Apply Sequential Thinking
+### 2. Evaluate the Plan
 
-Use sequential thinking to evaluate the plan systematically:
+Work through the plan systematically — reason inline; reach for Sequential Thinking only if the plan is large or genuinely tangled.
 
 **For each plan slice, answer:**
 

--- a/internal/plugin/agents/tdd-refactorer.md
+++ b/internal/plugin/agents/tdd-refactorer.md
@@ -95,8 +95,8 @@ Name the pattern in your return summary (e.g., "Extract Method — pulled valida
 
 Run tests using the command from your phase brief, scoped by test type:
 - **Unit tests:** run the test file only
-- **Integration tests:** run the full suite
-- **E2E tests:** run the E2E suite
+- **Integration tests:** run the affected feature's test file(s) only — **not** the full suite (full regression is the CI/PR gate)
+- **E2E tests:** run the relevant spec only
 
 ## Return (MANDATORY)
 

--- a/internal/plugin/agents/tdd-test-writer.md
+++ b/internal/plugin/agents/tdd-test-writer.md
@@ -1,7 +1,7 @@
 ---
 name: tdd-test-writer
 description: "Writes comprehensive tests based on approved strategy and verifies they fail correctly (RED phase)"
-model: opus
+model: sonnet
 tools: Read, Grep, Glob, Write, Edit, Bash
 color: red
 ---

--- a/internal/plugin/skills/tdd/SKILL.md
+++ b/internal/plugin/skills/tdd/SKILL.md
@@ -17,6 +17,8 @@ Context-isolated RED/GREEN/REFACTOR. Each phase runs in a separate subagent to p
 
 **Lifecycle:** This skill spans the ENTIRE session. After planning completes (Stage 0), continue with Session Constants → The Loop. **Never use `EnterPlanMode`** — it causes context amnesia. Use the Plan subagent instead.
 
+**Orchestrator judgment (you run on Opus):** You are the master brain. Make cheap routing calls *inline* — whether code needs prep, whether a diff needs refactoring, which test is next — rather than spawning an agent or running a formal thinking pass to decide nothing. Spawn subagents when there's real work; use **Sequential Thinking only when a decision is genuinely hard** (ambiguous scope, tangled decomposition, subtle bug). Default to reasoning directly. The subagent model tiers reflect this: **Sonnet** for per-cycle test-writing, **Haiku** for implementation/refactoring execution, **Opus** reserved for one-shot high-stakes reasoning (plan review, regression analysis). You (the orchestrator) inherit the main chat's model — the skill never sets it.
+
 ## Mode Detection
 
 | User Signal | Mode |
@@ -37,18 +39,14 @@ See [when-to-skip-tdd.md](references/when-to-skip-tdd.md) for detailed criteria,
 
 ### Branch Creation (First Thing)
 
-Before any exploration or planning, pull latest main and create a feature branch:
-
-```bash
-git checkout main && git pull origin main && git checkout -b <type>/<short-slug>
-```
+Before any exploration or planning, get onto a fresh feature branch — **following the project's branching conventions** (check the project and global `CLAUDE.md`). Do **not** hardcode `git checkout main`: in worktree-based setups `main` is checked out elsewhere, so that command fails or detaches you. Branch from the current HEAD / latest default branch however the project's setup dictates.
 
 - **Name it yourself** — don't ask the user. Derive from the feature/bug description.
 - `feat/add-category-search`, `fix/duplicate-household-creation`, `refactor/extract-validation-logic`
 - Use the same `type` prefix as the commits (`feat/`, `fix/`, `refactor/`)
 - Keep it short (3-5 words max, kebab-case)
 
-This ensures all exploration, planning, and coding happens against the latest codebase.
+This ensures all exploration, planning, and coding happens on a clean branch against the latest codebase.
 
 ### Planning Decision Tree
 
@@ -78,7 +76,7 @@ This ensures all exploration, planning, and coding happens against the latest co
 - Plan approved → Proceed to **Stage 0f** (Acceptance Test)
 
 **0f — Acceptance Test (GOOS Outer Loop)**
-After plan is approved, before inner loop begins. Use Sequential Thinking: does this feature have user-facing behaviour (new page, form, flow, navigation, toast, dialog)?
+After plan is approved, before inner loop begins. Decide inline: does this feature have user-facing behaviour (new page, form, flow, navigation, toast, dialog)?
 - YES → spawn tdd-test-writer in `Mode: acceptance` (see [phase-prompts.md](references/phase-prompts.md#stage-0f-acceptance-test-goos-outer-loop))
 - NO → skip 0f, set `Acceptance test path: none` in session constants
 
@@ -95,14 +93,14 @@ Then proceed to **Session Constants** (Stage 0a) → inner loop.
 
 ### Session Constants
 
-Discovered during Stage 0 (Explore agent) and reused in every phase brief. When discovering constants, also find: E2E test command (`playwright` in package.json scripts), E2E test directory (look for `tests/e2e/` or `e2e/`), and auth fixture path (look for `auth-fixture.ts` in E2E directories).
+Discovered during Stage 0 (Explore agent) and reused in every phase brief. Prefer values the project's `CLAUDE.md` already documents (test commands especially); otherwise discover them. When discovering constants, also find: E2E test command (`playwright` in package.json scripts), E2E test directory (look for `tests/e2e/` or `e2e/`), and auth fixture path (look for `auth-fixture.ts` in E2E directories). Also resolve the **absolute** path to this skill's bundled `references/test-standards.md` (wherever the plugin is installed) so subagents can actually read it.
 
 | Constant | Example | Notes |
 |----------|---------|-------|
 | Test command | `pnpm vitest run --reporter=verbose --bail 1` | `--bail 1` stops on first failure — faster feedback in GREEN and REFACTOR gates |
 | Test file pattern | colocated `*.test.ts` or `tests/__tests__/` | |
 | Test helpers | `tests/helpers/isolated-test-household.ts` | |
-| Standards file | `.claude/skills/tdd/references/test-standards.md` | |
+| Standards file | absolute path to this skill's `references/test-standards.md` | Resolve in Stage 0 (plugin install path — not a hardcoded `.claude/` path) |
 | Bug context | PR #123 or main..fix/bug or diagnosis summary | (empty for features) |
 | E2E test command | `pnpm playwright test` | Discovered in Stage 0a |
 | E2E test directory | `tests/e2e/` | Discovered in Stage 0a |
@@ -137,21 +135,12 @@ Read the active plan file in `docs/plans/`. Find the **first unchecked** `- [ ]`
 
 **If this is the first unchecked test of a new slice** → `TaskUpdate` the slice's task to `status: in_progress`.
 
-### 2. TIDY FIRST — Prep refactoring (always)
+### 2. TIDY FIRST — Prep refactoring (only when needed)
 
-**Always spawn the tdd-refactorer subagent for prep analysis.** It will read the code the next test will touch and decide whether prep tidying is needed.
+**You (Opus) judge whether the code the next test will touch needs structural prep** before new behavior goes in (Kent Beck's "Tidy First?"). Spawn the tdd-refactorer (Mode: PREP) **only if** there's a real reason: a long/tangled function about to grow, poor naming that obscures where the new code goes, or duplication the new code would amplify.
 
-Why this works:
-- Agent evaluates actual code structure, not orchestrator's guess
-- Fast decisions (~5 sec with Haiku) when code is ready
-- Consistent with POST-GREEN refactor approach
-- Removes heuristic from orchestrator
-
-Compose phase brief (see [phase-prompts.md](references/phase-prompts.md#tidy-first-phase-tdd-refactorer-prep)) with next test description and files to be modified.
-
-**Refactorer will either:**
-- Skip: "Code is ready — clean structure, easy to extend"
-- Prep tidy: Make structural changes to create space for new behavior
+- **New code, or target already clean/small/clear** → skip the spawn, note `TIDY FIRST: skip`, go to RED. Don't launch an agent to be told "SKIP".
+- **Genuine prep needed** → spawn tdd-refactorer with the brief (see [phase-prompts.md](references/phase-prompts.md#tidy-first-phase-tdd-refactorer-prep)); structural changes only.
 
 **GATE:** ALL tests still PASS after tidying (when tidying is done).
 
@@ -165,14 +154,11 @@ refactor: [prep tidy — what was restructured and why]
 
 ### 3. RED — Spawn tdd-test-writer
 
-**Before spawning:** Use Sequential Thinking to verify:
-1. Which specific test from the plan is next?
-2. How many tests should tdd-test-writer write? (Answer: EXACTLY ONE)
-3. Why one? (TDD requires tight feedback: 1 test → 1 implementation → 1 refactor. Batching breaks the cycle.)
+**Before spawning,** confirm inline (no formal thinking pass): the next unchecked plan item is the next test, and the brief asks for **EXACTLY ONE** test (1 test → 1 implementation → 1 refactor; batching breaks the cycle). Reach for Sequential Thinking only if the next test is genuinely ambiguous.
 
 Compose a lean phase brief using the template from [phase-prompts.md](references/phase-prompts.md#red-phase-tdd-test-writer). Pass file paths, not file contents.
 
-Spawn `tdd-test-writer` subagent.
+Spawn `tdd-test-writer` subagent on **Sonnet** (writing one test from a vetted plan item is well within Sonnet's range, and runs every cycle).
 
 **GATE 1 — Test Count:** Verify tdd-test-writer added EXACTLY ONE test.
 - One test added → proceed to GATE 2
@@ -217,21 +203,11 @@ test: [test description]
 feat: [what was implemented to pass it]
 ```
 
-### 5. REFACTOR — Spawn tdd-refactorer (always)
+### 5. REFACTOR — Spawn tdd-refactorer (only when needed)
 
-**Always spawn the tdd-refactorer subagent.** It will analyze the code and decide whether refactoring is needed or skip.
+**You (Opus) judge the GREEN diff.** If it introduced something worth cleaning — duplication, a complex conditional, unclear naming, or it's more than ~10 lines — spawn the tdd-refactorer (Mode: REFACTOR). If the change is small and clean, skip the spawn, note `REFACTOR: skip`, and move on. (Cumulative mess is still caught by the mandatory full-slice refactor at each slice boundary — see step 6.)
 
-Why this works:
-- Agent has better context by reading the actual code
-- With Haiku model, "no refactoring needed" decisions are fast (~5 sec) and cheap
-- Removes heuristic judgment from orchestrator
-- Consistent process every cycle
-
-Compose phase brief (see [phase-prompts.md](references/phase-prompts.md#refactor-phase-tdd-refactorer)) with test + implementation file paths.
-
-**Refactorer will either:**
-- Skip: "No refactoring needed — change is clean/small/well-structured"
-- Refactor: Make structural improvements, verify tests still pass
+Compose phase brief (see [phase-prompts.md](references/phase-prompts.md#refactor-phase-tdd-refactorer)) with test + implementation file paths. Bump the refactorer to `model: "sonnet"` for a substantial multi-file refactor; Haiku is fine for localized cleanups.
 
 **GATE:** ALL tests still PASS after refactoring (when refactoring is done).
 
@@ -274,6 +250,10 @@ Read the plan file:
 - Don't re-read plan file if you already know next test
 - Don't re-read test file if gate just passed
 - Trust subagent results
+
+❌ **Formal Sequential Thinking for routine calls**
+- The one-test check, PREP/REFACTOR skip decisions, and "which test is next" are inline judgments
+- Save Sequential Thinking for genuinely hard cases (ambiguous scope, subtle bug)
 
 #### What to Keep Doing
 
@@ -338,7 +318,7 @@ Otherwise, run: `{e2e_test_command} {acceptance_test_path}`
 **PASSES** → proceed to completion banner.
 
 **FAILS** → gap cycle (max 2):
-1. Use Sequential Thinking to identify the specific failing assertion
+1. Identify the specific failing assertion (Sequential Thinking only if the failure is non-obvious)
 2. Create a "Gap" slice: describe the missing behaviour precisely
 3. Run one RED-GREEN-REFACTOR cycle for the gap (unit/integration mode, not acceptance mode)
 4. Re-run acceptance test
@@ -468,7 +448,7 @@ Same as Feature loop step 5. If refactoring done, commit separately as `refactor
 
 **Applies to:** Both feature and bug-fix modes
 
-**Use Sequential Thinking to evaluate:**
+**Evaluate** (inline; Sequential Thinking only if the call is genuinely close):
 
 > "Given test coverage and change scope, is deep edge case analysis (10 min, Opus) likely to find meaningful gaps?"
 

--- a/internal/plugin/skills/tdd/references/phase-prompts.md
+++ b/internal/plugin/skills/tdd/references/phase-prompts.md
@@ -15,7 +15,7 @@ Plan file: {plan_file_path}            # e.g., "docs/plans/2026-02-07-category-s
 Test command: {test_command}           # e.g., "pnpm vitest run --reporter=verbose"
 Test file pattern: {test_pattern}       # e.g., "colocated *.test.ts" or "tests/__tests__/"
 Test helpers: {helper_paths}            # e.g., "tests/helpers/isolated-test-household.ts"
-Standards file: {standards_path}        # .claude/skills/tdd/references/test-standards.md
+Standards file: {standards_path}        # this skill's bundled references/test-standards.md (absolute path resolved in Stage 0)
 E2E test command: {e2e_test_command}   # e.g., "pnpm playwright test"
 E2E test directory: {e2e_test_dir}     # e.g., "tests/e2e/"
 Auth fixture: {auth_fixture_path}      # e.g., "tests/e2e/fixtures/auth-fixture.ts"
@@ -35,7 +35,7 @@ User chose "Auto-generate plan" from Stage 0-plan heuristic gate.
 ````
 Task tool:
   subagent_type: "Plan"
-  model: "opus"
+  model: "sonnet"
   description: "Generate TDD implementation plan"
   prompt: |
     ## Task
@@ -110,7 +110,7 @@ Task tool:
        - pgtap: Database constraints, triggers, RLS (PostgreSQL)
 
     6. **Context to read before planning**:
-       - `.claude/skills/tdd/references/test-standards.md` — testing patterns
+       - this skill's bundled `references/test-standards.md` — testing patterns
        - Existing test files in the codebase — follow conventions
        - Related source files — understand current architecture
        - Database schema if relevant (supabase/migrations/)
@@ -147,7 +147,7 @@ Fresh eyes quality gate — catch TDD gaps, YAGNI violations, missing slices, ar
 
 ````
 Task tool:
-  subagent_type: "general-purpose"
+  subagent_type: "tdd-plan-reviewer"
   model: "opus"
   description: "Review TDD plan for quality and completeness"
   prompt: |
@@ -163,7 +163,7 @@ Task tool:
 
     ## Evaluation Criteria
 
-    For each plan slice, use sequential thinking to evaluate:
+    For each plan slice, evaluate (use Sequential Thinking only for genuinely complex plans):
 
     1. **Testability** — Can you write a failing test for this slice? Is there a clear assertion that will pass/fail?
     2. **Slice Scope** — Is this a single logical unit or mixing multiple concerns?
@@ -261,9 +261,9 @@ Task tool:
 
 ## TIDY FIRST Phase: tdd-refactorer (prep)
 
-**When:** Before RED phase, to prep existing code for new behavior.
+**When:** Before RED, **only if the Opus orchestrator judges the code the next test will touch needs structural prep** — a long/tangled function about to grow, poor naming that obscures where the new code goes, or duplication the new code would amplify. For new code or already-clean targets, **skip the spawn entirely** — don't pay an agent launch to be told "SKIP".
 
-**Purpose:** Evaluate if existing code needs structural changes before adding new behavior (Kent Beck's "Tidy First?" pattern).
+**Purpose:** Create space for new behavior before writing the test (Kent Beck's "Tidy First?" pattern), when there's genuinely something to tidy.
 
 ````
 Task tool:
@@ -282,36 +282,21 @@ Task tool:
 
 ## RED Phase: tdd-test-writer
 
-### Pre-RED Sequential Thinking (Orchestrator)
+### Pre-RED check (Orchestrator)
 
-Before spawning tdd-test-writer, the orchestrator MUST use Sequential Thinking to verify the "one test" constraint:
+Confirm two things inline before spawning tdd-test-writer — Opus does this in a sentence, no formal thinking pass:
 
-```
-mcp__sequential-thinking__sequentialthinking:
-  thought: "I need to spawn tdd-test-writer for the RED phase. Let me verify what I'm asking it to do."
-  thoughtNumber: 1
-  totalThoughts: 3
-  nextThoughtNeeded: true
+1. The next unchecked plan item is ONE specific test.
+2. The brief asks for EXACTLY ONE test — never "tests for these rules" (that implies batching).
 
-  thought: "Looking at the plan file, the next unchecked test is: '{specific_test_description}'. That's ONE specific test."
-  thoughtNumber: 2
-  totalThoughts: 3
-  nextThoughtNeeded: true
-
-  thought: "I will spawn tdd-test-writer with a brief that says: write EXACTLY ONE test for '{specific_test_description}'. Not multiple tests for this function. Not a batch of simple tests. ONE test. This is a hard gate — if tdd-test-writer adds multiple tests, I must reject the work and respawn with a stronger constraint."
-  thoughtNumber: 3
-  totalThoughts: 3
-  nextThoughtNeeded: false
-```
-
-This explicit reasoning prevents the orchestrator from accidentally encouraging batching (e.g., "write tests for these validation rules" → implies multiple tests).
+Sequential Thinking is available but **not required** here — reach for it only if the next test is genuinely ambiguous (unclear boundary, multiple plausible interpretations). The ONE TEST gate is still hard; verifying it just doesn't warrant a ritual.
 
 ### Template
 
 ```
 Task tool:
   subagent_type: "tdd-test-writer"
-  model: "opus"
+  model: "sonnet"
   description: "RED: {test_description}"
   prompt: |
     Mode: unit/integration  # Always "unit/integration" in inner loop. Acceptance test was written once in Stage 0f.
@@ -375,6 +360,8 @@ Task tool:
 
 ## REFACTOR Phase: tdd-refactorer
 
+**When:** After GREEN, **only if the orchestrator sees something worth cleaning** — duplication, a complex conditional, unclear naming, or a GREEN diff larger than ~10 lines. Trivial diffs: skip the spawn. A full-slice refactor still runs once at each slice boundary as the safety net. Bump `model` to `sonnet` for a substantial multi-file refactor; Haiku is fine for localized cleanups.
+
 ````
 Task tool:
   subagent_type: "tdd-refactorer"
@@ -403,7 +390,7 @@ Task tool:
   prompt: |
     You are performing regression analysis at the end of a TDD workflow.
 
-    Read `.claude/skills/tdd/references/regression-analysis.md` for full methodology.
+    Read this skill's bundled `references/regression-analysis.md` for full methodology.
 
     ## Context
     Feature/Bug: {description from plan or diagnosis}
@@ -411,7 +398,7 @@ Task tool:
     Tests written: {list of test files created/modified}
 
     ## Your Task
-    1. Use Sequential Thinking to analyze the change for patterns, edge cases, and integration risks
+    1. Analyze the change for patterns, edge cases, and integration risks (use Sequential Thinking if the change is complex or the pattern space is large)
     2. Search codebase (Grep/Read) to verify findings
     3. Generate test recommendations using the priority rubric
     4. Return findings in the mandatory output format (see regression-analysis.md)

--- a/internal/plugin/skills/tdd/references/planning-workflow.md
+++ b/internal/plugin/skills/tdd/references/planning-workflow.md
@@ -96,7 +96,7 @@ Task tool:
   model: "sonnet"
   description: "Generate TDD implementation plan"
   prompt: |
-    Read `.claude/skills/tdd/references/test-standards.md` for testing patterns.
+    Read this tdd skill's bundled `references/test-standards.md` for testing patterns (the orchestrator passes its absolute path).
 
     Task: Create a TDD implementation plan in Kent Beck format.
 
@@ -181,7 +181,7 @@ Spawn Explore agent (`subagent_type="Explore"`, thoroughness `"very thorough"`).
 - Test command: `pnpm vitest run --reporter=verbose`
 - Test file pattern: colocated `*.test.ts` or `tests/__tests__/`
 - Test helpers: `tests/helpers/isolated-test-household.ts`
-- Standards file: `.claude/skills/tdd/references/test-standards.md`
+- Standards file: this skill's bundled `references/test-standards.md` (absolute path resolved in Stage 0)
 - Bug context: PR #123 or main..fix/bug or diagnosis (empty for features)
 
 ### 0b. Clarify Intent
@@ -202,7 +202,7 @@ If a GitHub issue exists, read it (including comments) — but still confirm und
 
 **Use Context7 MCP** first if feature involves framework behavior (Next.js, Supabase, React).
 
-Use **Sequential Thinking** to decompose into ordered incremental slices. Each slice = one RED-GREEN-REFACTOR cycle that builds on the previous.
+Decompose into ordered incremental slices — each slice = one RED-GREEN-REFACTOR cycle that builds on the previous. Reason inline; reach for Sequential Thinking only if the decomposition is genuinely tangled.
 
 **Output format (for user approval):**
 
@@ -228,7 +228,7 @@ Slice 3: [edge cases + error handling]
 
 ### 0d. Write Plan
 
-After user approves slices, **decompose each slice into individual tests** using Sequential Thinking and write to `docs/plans/YYYY-MM-DD-<feature-slug>.md`.
+After user approves slices, **decompose each slice into individual tests** and write to `docs/plans/YYYY-MM-DD-<feature-slug>.md`. (Use Sequential Thinking only if a slice is genuinely hard to break down.)
 
 Use today's date. Slugify the feature name (lowercase, hyphens).
 

--- a/internal/plugin/skills/tdd/references/regression-analysis.md
+++ b/internal/plugin/skills/tdd/references/regression-analysis.md
@@ -16,9 +16,9 @@
 - What tests were written? (test files, assertions)
 - What constraints/boundaries exist? (validation, limits, data types)
 
-### 2. Pattern Analysis (Sequential Thinking)
+### 2. Pattern Analysis
 
-**Use Sequential Thinking (Opus) to explore:**
+**Explore the change (use Sequential Thinking only if the pattern space is large or non-obvious):**
 
 #### a. Same Pattern Class
 - What other code has this same structure?
@@ -163,7 +163,7 @@ What would you like to do?
 
 ### ALWAYS
 - Use Opus model (deep reasoning required)
-- Use Sequential Thinking for pattern analysis
+- Use Sequential Thinking when the pattern analysis is genuinely complex — not by default
 - Verify findings with code search before reporting
 - Filter false positives — only report real gaps
 - Prioritize findings (don't flood with low-value tests)


### PR DESCRIPTION
## Why

`/tdd` produces tidy, consistent results but is **slow** in everyday use. The skill was written defensively for a weak orchestrator — a mandatory Sequential Thinking pass before nearly every step, always-spawning the PREP and REFACTOR agents, and Opus on the per-cycle test-writer. With Opus now running the loop as the master brain, that's pure latency. This pushes cheap routing decisions back up to the orchestrator and reserves heavy models for genuine one-shot reasoning.

## Speed

- **RED test-writer Opus → Sonnet** — runs every cycle; writing one test from a plan-reviewer-vetted item is well within Sonnet's range. Biggest per-cycle win.
- **PREP & REFACTOR spawn only when needed** — the Opus orchestrator decides from the plan item / GREEN diff whether there's real work, instead of launching a Haiku agent every cycle just to be told "SKIP". The mandatory full-slice refactor at each slice boundary stays as the safety net.
- **GREEN/REFACTOR run the feature's test file(s) only**, not the full integration suite every cycle (this also fixes a contradiction — the orchestrator gate already said feature-file-only; full regression is the CI/PR gate).
- **Sequential Thinking demoted** everywhere from "MUST, every time" to "available, only when the decision is genuinely hard."
- Plan subagent settled on **Sonnet** (was an opus/sonnet conflict between two refs); the Opus plan-reviewer still vets it.

## Correctness / placement

- **Fixed 6 dead `.claude/skills/tdd/...` reference paths** — the skill ships as a plugin, so that pre-plugin path never resolved and subagents silently ran without the standards file. Orchestrator now resolves the bundled `references/` absolute path in Stage 0 and passes it down.
- **Branch creation no longer hardcodes `git checkout main`** — it breaks worktree setups (default branch checked out elsewhere). Defers to project/global `CLAUDE.md` conventions.
- **Plan-review phase spawns `tdd-plan-reviewer`** (template had drifted to `general-purpose`).
- Session constants prefer test commands the project `CLAUDE.md` already documents.

## Model tiers after this change

| Subagent | Model | Why |
|---|---|---|
| test-writer (RED) | Sonnet | per-cycle |
| implementer (GREEN) | Haiku (Sonnet override) | per-cycle execution |
| refactorer (PREP/REFACTOR) | Haiku (Sonnet override) | per-cycle execution, only when needed |
| Plan | Sonnet | reviewed downstream |
| plan-reviewer | Opus | one-shot quality gate |
| regression-analyst | Opus | one-shot deep analysis |
| orchestrator | inherits main chat | skill never sets it |

8 files, +53 / −86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)