### PR TITLE
feat(tdd): add PreToolUse phase-gate hook to enforce RED/GREEN/REFACTOR

### DIFF
--- a/internal/plugin/hooks/hooks.json
+++ b/internal/plugin/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "Rocket Fuel TDD phase gate — enforces RED/GREEN/REFACTOR file discipline when a repo has an active .tdd-phase file",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/tdd-gate.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/internal/plugin/hooks/tdd-gate.sh
+++ b/internal/plugin/hooks/tdd-gate.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# tdd-gate.sh — PreToolUse (Edit|Write|MultiEdit) gate enforcing TDD phase discipline.
+# Shipped by the rocket-fuel plugin; registered via hooks/hooks.json.
+#
+# Reads a `.tdd-phase` file at the repo root (RED|GREEN|REFACTOR). Absent => invisible.
+#   RED      : may edit tests, NOT source  (write the failing test first)
+#   GREEN    : may edit source, NOT tests  (fix the impl, not the test)
+#   REFACTOR : may edit source, NOT tests  (keep the contract green)
+# Always allows the .tdd-phase file and .md/plan bookkeeping.
+# Minimal content ban: refuses edits that add `.only(` or `.skip(`.
+# Logs every active invocation to ~/.claude/tdd-gate.log for observability.
+
+input=$(cat)
+
+# No jq -> don't get in the way.
+command -v jq >/dev/null 2>&1 || { printf '{"hookSpecificOutput":{}}'; exit 0; }
+
+neutral() { printf '{"hookSpecificOutput":{}}'; exit 0; }
+
+tool=$(echo "$input" | jq -r '.tool_name // "?"')
+fp=$(echo "$input"  | jq -r '.tool_input.file_path // .tool_input.path // ""')
+[ -z "$fp" ] && neutral
+
+# Walk up from the edited file to find the repo's .tdd-phase
+dir=$(dirname "$fp"); phase_file=""
+while [ -n "$dir" ] && [ "$dir" != "/" ] && [ "$dir" != "." ]; do
+  if [ -f "$dir/.tdd-phase" ]; then phase_file="$dir/.tdd-phase"; break; fi
+  dir=$(dirname "$dir")
+done
+[ -z "$phase_file" ] && neutral            # gate not active for this repo
+
+phase=$(tr -d '[:space:]' < "$phase_file")
+base=$(basename "$fp")
+content=$(echo "$input" | jq -r '.tool_input.new_string // .tool_input.content // ""')
+
+log()   { echo "$(date +%H:%M:%S) tool=$tool phase=${phase:-none} fp=$fp -> $1" >> "$HOME/.claude/tdd-gate.log"; }
+allow() { log ALLOW; printf '{"hookSpecificOutput":{}}'; exit 0; }
+deny()  { log "DENY: $1"; printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}' "$1"; exit 0; }
+
+# Bookkeeping is always allowed
+[ "$base" = ".tdd-phase" ] && allow
+case "$fp" in *.md) allow ;; esac
+
+# Minimal content ban (any phase)
+case "$content" in
+  *".only("*) deny "TDD: refusing to add .only( — it silently disables sibling tests." ;;
+  *".skip("*) deny "TDD: refusing to add .skip( — don't skip the test you're meant to make pass." ;;
+esac
+
+# Classify test vs source
+case "$fp" in
+  *.test.*|*.spec.*|*/__tests__/*|*/tests/*|*/supabase/tests/*) is_test=1 ;;
+  *) is_test=0 ;;
+esac
+
+case "$phase" in
+  RED)
+    [ "$is_test" = 0 ] && deny "TDD RED: write the failing test first — edit tests only. Set .tdd-phase=GREEN once it fails, then edit source."
+    allow ;;
+  GREEN|REFACTOR)
+    [ "$is_test" = 1 ] && deny "TDD $phase: don't edit tests now — fix the implementation. (Set .tdd-phase=RED to change the contract.)"
+    allow ;;
+  *)
+    neutral ;;   # unknown phase value -> stay out of the way
+esac

--- a/internal/plugin/hooks/tdd-gate.test.sh
+++ b/internal/plugin/hooks/tdd-gate.test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Offline test matrix for tdd-gate.sh — no Claude Code involved.
+# Pipes synthetic PreToolUse payloads at the hook and asserts allow/deny.
+# Run: ./tdd-gate.test.sh   (resolves the hook next to this script)
+set -u
+HOOK="$(cd "$(dirname "$0")" && pwd)/tdd-gate.sh"
+PASS=0; FAIL=0
+
+T="$(mktemp -d)"
+mkdir -p "$T/src" "$T/tests" "$T/docs/plans"
+trap 'rm -rf "$T"' EXIT
+
+set_phase()   { printf '%s' "$1" > "$T/.tdd-phase"; }
+clear_phase() { rm -f "$T/.tdd-phase"; }
+
+run_case() { # <desc> <ALLOW|DENY> <payload>
+  local desc="$1" expect="$2" payload="$3" out decision
+  out="$(printf '%s' "$payload" | "$HOOK" 2>/dev/null)"
+  if echo "$out" | grep -q '"permissionDecision":"deny"'; then decision=DENY; else decision=ALLOW; fi
+  if [ "$decision" = "$expect" ]; then
+    PASS=$((PASS+1)); printf '  ✓ %s\n' "$desc"
+  else
+    FAIL=$((FAIL+1)); printf '  ✗ %s — expected %s got %s\n     out: %s\n' "$desc" "$expect" "$decision" "$out"
+  fi
+}
+
+payload() { # <tool> <file_path> [content]
+  printf '{"tool_name":"%s","tool_input":{"file_path":"%s","content":"%s","new_string":"%s"}}' \
+    "$1" "$2" "${3:-}" "${3:-}"
+}
+
+echo "== RED phase =="
+set_phase RED
+run_case "RED: edit test file  -> ALLOW" ALLOW "$(payload Edit "$T/tests/foo.test.ts")"
+run_case "RED: edit source     -> DENY"  DENY  "$(payload Edit "$T/src/foo.ts")"
+run_case "RED: edit plan .md   -> ALLOW" ALLOW "$(payload Edit "$T/docs/plans/p.md")"
+run_case "RED: write .tdd-phase-> ALLOW" ALLOW "$(payload Write "$T/.tdd-phase")"
+
+echo "== GREEN phase =="
+set_phase GREEN
+run_case "GREEN: edit source    -> ALLOW" ALLOW "$(payload Edit "$T/src/foo.ts")"
+run_case "GREEN: edit test file -> DENY"  DENY  "$(payload Edit "$T/tests/foo.test.ts")"
+
+echo "== REFACTOR phase =="
+set_phase REFACTOR
+run_case "REFACTOR: edit source    -> ALLOW" ALLOW "$(payload Edit "$T/src/foo.ts")"
+run_case "REFACTOR: edit test file -> DENY"  DENY  "$(payload Edit "$T/tests/foo.test.ts")"
+
+echo "== content bans (minimal) =="
+set_phase RED
+run_case "RED: add .only( to test -> DENY"  DENY  "$(payload Edit "$T/tests/foo.test.ts" "it.only(")"
+run_case "RED: add .skip( to test -> DENY"  DENY  "$(payload Edit "$T/tests/foo.test.ts" "it.skip(")"
+run_case "RED: normal test edit   -> ALLOW" ALLOW "$(payload Edit "$T/tests/foo.test.ts" "expect(x).toBe(1)")"
+
+echo "== invisible when no .tdd-phase =="
+clear_phase
+run_case "no phase: edit source -> ALLOW" ALLOW "$(payload Edit "$T/src/foo.ts")"
+run_case "no phase: edit test   -> ALLOW" ALLOW "$(payload Edit "$T/tests/foo.test.ts")"
+
+echo
+echo "RESULT: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Moves TDD's phase discipline from prompt instructions (soft, and getting softer as more subagents are added) to a deterministic harness gate.

A `PreToolUse` hook on `Edit|Write|MultiEdit` reads a `.tdd-phase` file at the repo root and blocks edits that violate the current phase:

| Phase | Tests | Source |
|---|---|---|
| RED | allow | deny |
| GREEN | deny | allow |
| REFACTOR | deny | allow |

Always allows the `.tdd-phase` file itself and `.md`/plan bookkeeping. Minimal content ban: refuses adding `.only(` / `.skip(`. Invisible when no `.tdd-phase` file exists, so it never affects non-TDD work or other repos.

Ships with the plugin via `hooks/hooks.json` using `${CLAUDE_PLUGIN_ROOT}`, and merges with user hooks.

## Verification

Verified empirically on Claude Code 2.1.185: `PreToolUse` fires on Edit/Write, deny is honoured, takes effect without restart, and works inside subagents — which are what actually perform edits during the TDD loop.

`tdd-gate.test.sh` is a 13-case offline matrix (pure stdin -> decision, no Claude Code needed):

```
RESULT: 13 passed, 0 failed
```

`go build ./... && go test ./...` green.

## Not yet wired

The `/tdd` skill still needs to write `.tdd-phase` at each transition, and `.tdd-phase` needs gitignoring. Tracked as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)