### PR TITLE
fix: drop dead /epc route and repair release tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,14 +27,37 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Auto-tag
+      - name: Compute version
         id: tag
         run: |
-          # Generate version from date + short hash
-          VERSION="v0.$(date +%Y%m%d).$(git rev-parse --short HEAD)"
-          git tag "$VERSION"
-          git push origin "$VERSION"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          # Semver: v0.<YYYYMMDD>.<n>, where n is the build number for that date.
+          # The previous scheme appended the short SHA, which is hex — any tag
+          # containing a letter failed GoReleaser's semver parse, so releases only
+          # ever succeeded when the SHA happened to be all digits.
+          DATE="$(date +%Y%m%d)"
+          N=0
+          while git rev-parse -q --verify "refs/tags/v0.${DATE}.${N}" >/dev/null; do
+            N=$((N + 1))
+          done
+          VERSION="v0.${DATE}.${N}"
+          echo "Resolved version: ${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify GoReleaser config before tagging
+        # Tag only after we know the release can build. The old workflow pushed the
+        # tag first, so every failed run left an orphan tag behind — 60+ of them.
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: check
+
+      - name: Tag
+        run: |
+          set -euo pipefail
+          git tag "${{ steps.tag.outputs.version }}"
+          git push origin "${{ steps.tag.outputs.version }}"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
@@ -44,3 +67,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Delete tag if release failed
+        if: failure()
+        run: git push --delete origin "${{ steps.tag.outputs.version }}" || true

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ rocket-fuel
 # Runtime artifacts installed/managed by `rf launch` (not source — see CLAUDE.md)
 .claude/worktrees/
 .claude/settings.json
+
+# GoReleaser build output
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,7 @@ builds:
 archives:
   - id: default
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    format: tar.gz
+    formats: [tar.gz]
 
 checksum:
   name_template: "checksums.txt"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Read `docs/vision.md` for the full concept, `docs/gastown-lessons.md` for prior 
 - **Visionary** = the human. Owns product direction (what/why). Scopes vague issues. Approves merges. Calls meetings.
 - **Integrator** = AI agent (Claude Code, runs continuously). Owns execution (how/when). Manages board, dispatches workers, reviews PRs. Never scopes issues — surfaces vague ones to the Visionary. Can call meetings when it needs the Visionary's input.
 - **Watchdog** = Go daemon (background). Keeps agents alive, detects stuck workers, reaps completed ones. No decisions — purely mechanical. Event-driven via Claude Code hooks.
-- **Workers** = ephemeral Claude Code instances in git worktrees. Run skills (`/tdd`, `/bug-fix`, `/epc`) on assigned issues. Fully autonomous (GUPP).
+- **Workers** = ephemeral Claude Code instances in git worktrees. Run skills (`/claude-skills:tdd`, `/claude-skills:issue-scope`) on assigned issues. Fully autonomous (GUPP).
 - **Mission Control** = Stream Deck plugin (separate repo: `drdanmaggs/mission-control`). Physical dashboard for the Visionary.
 
 See `docs/adr/002-agent-roles.md` for full role definitions and boundaries.

--- a/README.md
+++ b/README.md
@@ -133,8 +133,6 @@ Issues are routed to skills based on labels. The skills themselves live in the
 | `workflow:issue-scope` | `/claude-skills:issue-scope` | Break down into sub-issues |
 | *(no label)* | `/claude-skills:tdd` | Default — TDD always |
 
-`workflow:epc` routes to `/epc`, which does not currently exist in any plugin.
-
 ## Development
 
 ```bash

--- a/cmd/meet.go
+++ b/cmd/meet.go
@@ -50,7 +50,7 @@ Your job:
 1. Listen to the Visionary's ideas
 2. Help scope them into actionable GitHub issues (use /issue-scope if appropriate)
 3. Create well-documented issues with gh issue create
-4. Add appropriate labels (workflow:tdd, workflow:epc, etc.)
+4. Add appropriate labels (workflow:tdd, workflow:bug-fix, workflow:issue-scope)
 
 When the meeting ends, the Integrator will pick up the new issues from the board automatically.
 

--- a/internal/plugin/agents/integrator.md
+++ b/internal/plugin/agents/integrator.md
@@ -85,7 +85,7 @@ Don't ask permission for judgment calls. State your reasoning, then act. The Vis
 1. **Manage the GitHub Project board** — issues flow through columns. Use `gh project item-edit` to move items, `gh issue create` to add new ones.
 2. **Dispatch workers** — run `rf work <issue-number>` to spawn a Claude Code worker on a GitHub issue.
 3. **Monitor progress** — run `rf status` to check active workers, branches, and PR state.
-4. **Route work to skills** — based on issue labels: `workflow:tdd`, `workflow:bug-fix`, `workflow:epc`, `workflow:issue-scope`.
+4. **Route work to skills** — based on issue labels: `workflow:tdd`, `workflow:bug-fix`, `workflow:issue-scope`.
 5. **Reap completed workers** — run `rf reap` to clean up workers that have finished.
 6. **Track milestones** — flag when behind schedule.
 

--- a/internal/plugin/agents/worker.md
+++ b/internal/plugin/agents/worker.md
@@ -43,8 +43,7 @@ repo — hence the prefix.
 | `workflow:bug-fix`, `bug` | `/claude-skills:tdd` | Same loop — start with a failing test |
 | `workflow:issue-scope` | `/claude-skills:issue-scope` | Break down into sub-issues |
 
-`workflow:epc` routes to `/epc`, which does not exist in either plugin. If you are
-dispatched with it, fall back to `/claude-skills:tdd` and note it on the issue.
+Any other label falls through to `/claude-skills:tdd`.
 
 ## When you're done
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -62,8 +62,10 @@ func Spawn(tm tmux.Runner, cfg SpawnConfig, issue Issue) error {
 // drdanmaggs/claude-skills, not in this repo's plugin, so workers need both
 // plugins installed.
 //
-// The workflow:epc label still routes to a skill that does not exist in either
-// plugin — pre-existing, tracked separately.
+// Every returned skill must exist in an installed plugin. A route to a
+// non-existent skill is worse than no route at all: the worker spawns, burns a
+// worktree and a tmux session, then fails on an unknown command. Unrecognised
+// labels fall through to the TDD default instead.
 func RouteSkill(labels []string) string {
 	for _, label := range labels {
 		switch label {
@@ -71,8 +73,6 @@ func RouteSkill(labels []string) string {
 			return "/claude-skills:tdd"
 		case "workflow:bug-fix", "bug", "bug-fix":
 			return "/claude-skills:tdd"
-		case "workflow:epc":
-			return "/epc"
 		case "workflow:issue-scope":
 			return "/claude-skills:issue-scope"
 		}

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -76,11 +76,12 @@ func TestRouteSkillFromLabels(t *testing.T) {
 		{"bug-fix workflow label", []string{"workflow:bug-fix"}, "/claude-skills:tdd"},
 		{"bug label routes to tdd", []string{"bug"}, "/claude-skills:tdd"},
 		{"bug-fix label routes to tdd", []string{"bug-fix"}, "/claude-skills:tdd"},
-		{"epc label", []string{"workflow:epc"}, "/epc"},
+		{"epc label falls through to tdd default", []string{"workflow:epc"}, "/claude-skills:tdd"},
 		{"issue-scope label", []string{"workflow:issue-scope"}, "/claude-skills:issue-scope"},
 		{"no workflow label defaults to tdd", []string{"enhancement", "v0.1"}, "/claude-skills:tdd"},
 		{"empty labels defaults to tdd", nil, "/claude-skills:tdd"},
 		{"multiple labels picks first workflow", []string{"v0.1", "workflow:tdd", "workflow:epc"}, "/claude-skills:tdd"},
+		{"every routed skill is plugin-qualified", []string{"workflow:issue-scope"}, "/claude-skills:issue-scope"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Two independent breakages, both surfaced while auditing the repo after the skills split.

## 1. Dead `/epc` route (closes #233)

`RouteSkill` returned `/epc` for the `workflow:epc` label, but `/epc` exists in neither `rocket-fuel` nor `claude-skills`. A worker routed there spawns, claims a worktree and a tmux session, then dies on an unknown slash command — strictly worse than not routing at all.

The label now falls through to the `/claude-skills:tdd` default, which is what every unrecognised label already did. Test updated first, then the code.

Swept the label out of the worker and integrator agent definitions, the README routing table, the meeting prompt and `CLAUDE.md` — all of them were advertising a skill that doesn't exist. ADRs and `docs/vision.md` keep their references; those are point-in-time records, not live routing docs.

## 2. Releases have been broken since March

The tag was built as:

```bash
VERSION="v0.$(date +%Y%m%d).$(git rev-parse --short HEAD)"
```

A short SHA is hex, so any tag containing a letter fails GoReleaser's semver parse:

```
⨯ release failed after 0s error=failed to parse tag 'v0.20260725.f5f6dd3' as semver: invalid semantic version
```

Only an all-digit SHA worked — roughly a 1-in-25 fluke. **64 tags exist on origin; 2 releases do.** Latest release is 20 March, 182 commits ago.

Fixes:

- Version is now `v0.<YYYYMMDD>.<n>`, `n` being the build number for that date. Verified valid and correctly ordered with `golang.org/x/mod/semver` — including day rollover and monotonicity past the last real release.
- The tag is pushed **only after `goreleaser check` passes**, and deleted again if the release step fails. The old order pushed first, which is exactly how 60+ orphan tags accumulated.
- `archives.format` → `archives.formats`. Deprecated in GoReleaser v2 and a hard failure under `check` — so adding the gate would otherwise have broken the release a second way.
- `dist/` gitignored.

Validated with the real GoReleaser binary: `check` passes, and `build --snapshot` produces a working `rf` binary.

## Not included

The 62 orphan tags are still on origin. They aren't inert — GoReleaser treats them as the latest release when deriving snapshot versions and changelogs. Deleting them is irreversible and public, so it's a separate, explicit decision.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...`
- [x] `gofmt` / `go vet` / golangci-lint clean via pre-commit
- [x] `goreleaser check`
- [x] `goreleaser build --snapshot` → working binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)